### PR TITLE
Remove _0 and _1 from contact class

### DIFF
--- a/cpp/Contact.hpp
+++ b/cpp/Contact.hpp
@@ -90,24 +90,32 @@ public:
     _cell_facet_pairs[1] = get_cell_indices(_facets[1]);
   }
 
+  /// Return facets belonging to surface with index surface
+  /// @param[in] surface - the index of the surface
   const std::vector<int32_t>& facets(int surface) const
   {
     return _facets[surface];
   }
-  // Return meshtag value for surface
+
+  /// Return meshtag value for surface with index surface
+  /// @param[in] surface - the index of the surface
   const int surface_mt(int surface) const { return _surfaces[surface]; }
+
   // return quadrature degree
   const int quadrature_degree() const { return _quadrature_degree; }
   void set_quadrature_degree(int deg) { _quadrature_degree = deg; }
 
-  // return distance map
+  /// return distance map (adjacency map mapping quadrature points on surface
+  /// to closest facet on other surface)
+  /// @param[in] surface - index of the surface
   const std::shared_ptr<dolfinx::graph::AdjacencyList<std::int32_t>>
   facet_map(int surface) const
   {
     return _facet_maps[surface];
   }
 
-  // quadrature points on physical facet for each facet on surface
+  /// Return the quadrature points on physical facet for each facet on surface
+  /// @param[in] surface The index of the surface (0 or 1).
   std::vector<xt::xtensor<double, 2>> qp_phys(int surface)
   {
     return _qp_phys[surface];
@@ -1055,7 +1063,7 @@ public:
   /// Compute test functions on opposite surface at quadrature points of
   /// facets
   /// @param[in] orgin_meshtag - surface on which to integrate
-  /// @param[in] - gap packed on facets per quadrature point
+  /// @param[in] gap - gap packed on facets per quadrature point
   /// @param[out] c - test functions packed on facets.
   std::pair<std::vector<PetscScalar>, int>
   pack_test_functions(int origin_meshtag,

--- a/cpp/Contact.hpp
+++ b/cpp/Contact.hpp
@@ -812,8 +812,7 @@ public:
     const int gdim = mesh->geometry().dim(); // geometrical dimension
     auto puppet_facets = _cell_facet_pairs[origin_meshtag];
     _qp_phys[origin_meshtag].reserve(puppet_facets.shape(0));
-    auto qp_phys = _qp_phys[origin_meshtag];
-    qp_phys.clear();
+    _qp_phys[origin_meshtag].clear();
     // push forward of quadrature points _qp_ref_facet to physical facet for
     // each facet in _facet_"origin_meshtag"
     for (int i = 0; i < puppet_facets.shape(0); ++i)
@@ -836,7 +835,7 @@ public:
 
       // push forward of quadrature points _qp_ref_facet to the physical facet
       cmap.push_forward(q_phys, coordinate_dofs, _phi_ref_facets[local_index]);
-      qp_phys.push_back(q_phys);
+      _qp_phys[origin_meshtag].push_back(q_phys);
     }
   }
   /// Compute maximum number of links

--- a/cpp/contact_kernels.hpp
+++ b/cpp/contact_kernels.hpp
@@ -10,17 +10,14 @@
 #include <dolfinx/fem/FunctionSpace.h>
 #include <dolfinx_contact/Contact.hpp>
 #include <dolfinx_cuas/QuadratureRule.hpp>
+#include <dolfinx_cuas/kernels.hpp>
 #include <dolfinx_cuas/math.hpp>
 #include <dolfinx_cuas/utils.hpp>
 
-using kernel_fn
-    = std::function<void(double*, const double*, const double*, const double*,
-                         const int*, const std::uint8_t*)>;
-
 namespace dolfinx_contact
 {
-
-kernel_fn generate_contact_kernel(
+template <typename T>
+dolfinx_cuas::kernel_fn<T> generate_contact_kernel(
     std::shared_ptr<const dolfinx::fem::FunctionSpace> V, Kernel type,
     dolfinx_cuas::QuadratureRule& quadrature_rule,
     std::vector<std::shared_ptr<const dolfinx::fem::Function<PetscScalar>>>
@@ -143,7 +140,7 @@ kernel_fn generate_contact_kernel(
   // Define kernels
   // RHS for contact with rigid surface
   // =====================================================================================
-  kernel_fn nitsche_rigid_rhs
+  dolfinx_cuas::kernel_fn<T> nitsche_rigid_rhs
       = [=](double* b, const double* c, const double* w,
             const double* coordinate_dofs, const int* entity_local_index,
             const std::uint8_t* quadrature_permutation)
@@ -325,7 +322,7 @@ kernel_fn generate_contact_kernel(
 
   // Jacobian for contact with rigid surface
   // =====================================================================================
-  kernel_fn nitsche_rigid_jacobian
+  dolfinx_cuas::kernel_fn<T> nitsche_rigid_jacobian
       = [dphi_c, phi, dphi, phi_coeffs, dphi_coeffs, offsets, num_coeffs, gdim,
          tdim, fdim, q_weights, num_coordinate_dofs, ref_jacobians, bs,
          facet_normals, constant_normal](

--- a/python/demos/nitsche_unbiased_demo.py
+++ b/python/demos/nitsche_unbiased_demo.py
@@ -241,7 +241,8 @@ if __name__ == "__main__":
     # petsc_options = {"ksp_type": "preonly", "pc_type": "lu"}
     petsc_options = {"ksp_type": "cgs", "pc_type": "gamg", "pc_gamg_type": "agg", "pc_gamg_coarse_eq_limit": 1000,
                      "pc_gamg_sym_graph": True, "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "sor",
-                     "mg_levels_esteig_ksp_type": "cg", "matptap_via": "scalable", "pc_gamg_square_graph": 3, "pc_gamg_threshold": 1e-1, "ksp_view": None}
+                     "mg_levels_esteig_ksp_type": "cg", "matptap_via": "scalable", "pc_gamg_square_graph": 3,
+                     "pc_gamg_threshold": 1e-1, "ksp_view": None}
 
     # Pack mesh data for Nitsche solver
     mesh_data = (facet_marker, top_value, bottom_value, surface_value, surface_bottom)

--- a/python/demos/nitsche_unbiased_demo.py
+++ b/python/demos/nitsche_unbiased_demo.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
                 return x[1] > 0.5
 
             def bottom(x):
-                return x[1] < np.logical_and(x[1] < 0.45, x[1] > 0.11)
+                return x[1] < np.logical_and(x[1] < 0.25, x[1] > 0.11)
 
             top_value = 1
             bottom_value = 2
@@ -239,9 +239,9 @@ if __name__ == "__main__":
     # Solver options
     newton_options = {"relaxation_parameter": 1.0}
     # petsc_options = {"ksp_type": "preonly", "pc_type": "lu"}
-    petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "rtol": 1e-6, "pc_gamg_coarse_eq_limit": 1000,
-                     "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "jacobi",
-                     "mg_levels_esteig_ksp_type": "cg", "matptap_via": "scalable", "ksp_view": None}
+    petsc_options = {"ksp_type": "cgs", "pc_type": "gamg", "pc_gamg_type": "agg", "pc_gamg_coarse_eq_limit": 1000,
+                     "pc_gamg_sym_graph": True, "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "sor",
+                     "mg_levels_esteig_ksp_type": "cg", "matptap_via": "scalable", "pc_gamg_square_graph": 3, "pc_gamg_threshold": 1e-1, "ksp_view": None}
 
     # Pack mesh data for Nitsche solver
     mesh_data = (facet_marker, top_value, bottom_value, surface_value, surface_bottom)

--- a/python/dolfinx_contact/one_sided/nitsche_cuas.py
+++ b/python/dolfinx_contact/one_sided/nitsche_cuas.py
@@ -149,7 +149,7 @@ def nitsche_cuas(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.MeshTags, int, int],
     h_facets = dolfinx_contact.pack_circumradius_facet(mesh, bottom_facets)
 
     # Create contact class
-    contact = dolfinx_contact.cpp.Contact(facet_marker, contact_value, dirichlet_value, V._cpp_object)
+    contact = dolfinx_contact.cpp.Contact(facet_marker, [contact_value, dirichlet_value], V._cpp_object)
     contact.set_quadrature_degree(quadrature_degree)
     # Compute gap from contact boundary
     g_vec = contact.pack_gap_plane(0, -plane_loc)

--- a/python/dolfinx_contact/one_sided/nitsche_rigid_surface.py
+++ b/python/dolfinx_contact/one_sided/nitsche_rigid_surface.py
@@ -165,8 +165,8 @@ def nitsche_rigid_surface(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int
     gdim = mesh.geometry.dim
     fdim = mesh.topology.dim - 1
     mesh_geometry = mesh.geometry.x
-    contact.create_distance_map(0)
-    lookup = contact.map_0_to_1()
+    contact.create_distance_map(0, 1)
+    lookup = contact.facet_map(0)
     master_bbox = _geometry.BoundingBoxTree(mesh, fdim, contact_facets)
     midpoint_tree = _geometry.create_midpoint_tree(mesh, fdim, contact_facets)
 

--- a/python/dolfinx_contact/one_sided/nitsche_rigid_surface.py
+++ b/python/dolfinx_contact/one_sided/nitsche_rigid_surface.py
@@ -157,7 +157,7 @@ def nitsche_rigid_surface(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int
 
     # Create contact class
     contact_facets = facet_marker.indices[facet_marker.values == contact_value_elastic]
-    contact = dolfinx_contact.cpp.Contact(facet_marker, contact_value_elastic, contact_value_rigid, V._cpp_object)
+    contact = dolfinx_contact.cpp.Contact(facet_marker, [contact_value_elastic, contact_value_rigid], V._cpp_object)
     # Ensures that we find closest facet to midpoint of facet
     contact.set_quadrature_degree(1)
 
@@ -186,7 +186,7 @@ def nitsche_rigid_surface(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int
                 coords0 = mesh_geometry[facet_geometry][0]
                 R = np.linalg.norm(_cpp.geometry.compute_distance_gjk(coords0, xi))
                 # If point on a facet in contact surface (i.e., if distance between point and closest
-                # facet is 0), use contact.map_0_to_1() to find closest facet on rigid surface and
+                # facet is 0), use contact.facet_map(0) to find closest facet on rigid surface and
                 # compute distance vector
                 if np.isclose(R, 0):
                     facet_2 = lookup.links(index)[0]

--- a/python/dolfinx_contact/one_sided/nitsche_rigid_surface_cuas.py
+++ b/python/dolfinx_contact/one_sided/nitsche_rigid_surface_cuas.py
@@ -165,7 +165,7 @@ def nitsche_rigid_surface_cuas(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags
     contact.set_quadrature_degree(quadrature_degree)
 
     # Compute gap and normals
-    contact.create_distance_map(0)
+    contact.create_distance_map(0, 1)
     g_vec = contact.pack_gap(0)
     n_surf = contact.pack_ny(0, g_vec)
 

--- a/python/dolfinx_contact/one_sided/nitsche_rigid_surface_cuas.py
+++ b/python/dolfinx_contact/one_sided/nitsche_rigid_surface_cuas.py
@@ -161,7 +161,7 @@ def nitsche_rigid_surface_cuas(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags
     h_facets = dolfinx_contact.pack_circumradius_facet(mesh, contact_facets)
 
     # Create contact class
-    contact = dolfinx_contact.cpp.Contact(facet_marker, contact_value_elastic, contact_value_rigid, V._cpp_object)
+    contact = dolfinx_contact.cpp.Contact(facet_marker, [contact_value_elastic, contact_value_rigid], V._cpp_object)
     contact.set_quadrature_degree(quadrature_degree)
 
     # Compute gap and normals

--- a/python/dolfinx_contact/plotting.py
+++ b/python/dolfinx_contact/plotting.py
@@ -11,11 +11,11 @@ def plot_gap(mesh, contact, tag, gap):
     fdim = mesh.topology.dim - 1
     mesh_geometry = mesh.geometry.x
     if tag == 0:
-        facets = contact.facet_0()
-        facets_opp = contact.facet_1()
+        facets = contact.facets(0)
+        facets_opp = contact.facets(1)
     else:
-        facets = contact.facet_1()
-        facets_opp = contact.facet_0()
+        facets = contact.facets(1)
+        facets_opp = contact.facets(0)
 
     # Draw facets on opposite surface
     plt.figure()

--- a/python/dolfinx_contact/unbiased/nitsche_unbiased.py
+++ b/python/dolfinx_contact/unbiased/nitsche_unbiased.py
@@ -16,7 +16,6 @@ from petsc4py import PETSc as _PETSc
 import dolfinx_contact
 import dolfinx_contact.cpp
 from dolfinx_contact.helpers import epsilon, lame_parameters, sigma_func, rigid_motions_nullspace
-from dolfinx_contact.plotting import plot_gap
 
 kt = dolfinx_contact.cpp.Kernel
 

--- a/python/dolfinx_contact/unbiased/nitsche_unbiased.py
+++ b/python/dolfinx_contact/unbiased/nitsche_unbiased.py
@@ -136,7 +136,7 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int, int
     # Custom assembly
     _log.set_log_level(_log.LogLevel.OFF)
     # create contact class
-    contact = dolfinx_contact.cpp.Contact(facet_marker, surface_value_0, surface_value_1, V._cpp_object)
+    contact = dolfinx_contact.cpp.Contact(facet_marker, [surface_value_0, surface_value_1], V._cpp_object)
     contact.set_quadrature_degree(quadrature_degree)
     contact.create_distance_map(0, 1)
     contact.create_distance_map(1, 0)

--- a/python/dolfinx_contact/unbiased/nitsche_unbiased.py
+++ b/python/dolfinx_contact/unbiased/nitsche_unbiased.py
@@ -138,8 +138,8 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int, int
     # create contact class
     contact = dolfinx_contact.cpp.Contact(facet_marker, surface_value_0, surface_value_1, V._cpp_object)
     contact.set_quadrature_degree(quadrature_degree)
-    contact.create_distance_map(0)
-    contact.create_distance_map(1)
+    contact.create_distance_map(0, 1)
+    contact.create_distance_map(1, 0)
     # pack constants
     consts = np.array([gamma, theta])
 

--- a/python/dolfinx_contact/wrappers.cpp
+++ b/python/dolfinx_contact/wrappers.cpp
@@ -43,10 +43,10 @@ PYBIND11_MODULE(cpp, m)
   py::class_<dolfinx_contact::Contact,
              std::shared_ptr<dolfinx_contact::Contact>>(m, "Contact",
                                                         "Contact object")
-      .def(py::init<std::shared_ptr<dolfinx::mesh::MeshTags<std::int32_t>>, int,
-                    int, std::shared_ptr<dolfinx::fem::FunctionSpace>>(),
-           py::arg("marker"), py::arg("suface_0"), py::arg("surface_1"),
-           py::arg("V"))
+      .def(py::init<std::shared_ptr<dolfinx::mesh::MeshTags<std::int32_t>>,
+                    std::array<int, 2>,
+                    std::shared_ptr<dolfinx::fem::FunctionSpace>>(),
+           py::arg("marker"), py::arg("sufaces"), py::arg("V"))
       .def("create_distance_map",
            [](dolfinx_contact::Contact& self, int puppet_mt, int candidate_mt)
            {

--- a/python/dolfinx_contact/wrappers.cpp
+++ b/python/dolfinx_contact/wrappers.cpp
@@ -164,9 +164,9 @@ PYBIND11_MODULE(cpp, m)
              coeffs,
          bool constant_normal)
       {
-        return cuas_wrappers::KernelWrapper(
-            dolfinx_contact::generate_contact_kernel(V, type, q_rule, coeffs,
-                                                     constant_normal));
+        return cuas_wrappers::KernelWrapper<PetscScalar>(
+            dolfinx_contact::generate_contact_kernel<PetscScalar>(
+                V, type, q_rule, coeffs, constant_normal));
       },
       py::arg("V"), py::arg("kernel_type"), py::arg("quadrature_rule"),
       py::arg("coeffs"), py::arg("constant_normal") = true);

--- a/python/tests/test_contact_kernels.py
+++ b/python/tests/test_contact_kernels.py
@@ -126,7 +126,7 @@ def test_vector_surface_kernel(dim, kernel_type, P, Q):
     integral_entities = dolfinx_cuas.cpp.compute_active_entities(mesh, ft.indices, IntegralType.exterior_facet)
     coeffs = dolfinx_cuas.cpp.pack_coefficients([u._cpp_object, mu._cpp_object, lmbda._cpp_object], integral_entities)
     h_facets = dolfinx_contact.pack_circumradius_facet(mesh, facets)
-    contact = dolfinx_contact.cpp.Contact(ft, 1, 1, V._cpp_object)
+    contact = dolfinx_contact.cpp.Contact(ft, [1, 1], V._cpp_object)
     contact.set_quadrature_degree(2 * P + Q + 1)
     g_vec = contact.pack_gap_plane(0, -g)
     # FIXME: assuming all facets are the same type
@@ -247,7 +247,7 @@ def test_matrix_surface_kernel(dim, kernel_type, P, Q):
     integral_entities = dolfinx_cuas.cpp.compute_active_entities(mesh, facets, IntegralType.exterior_facet)
     coeffs = dolfinx_cuas.cpp.pack_coefficients([u._cpp_object, mu._cpp_object, lmbda._cpp_object], integral_entities)
     h_facets = dolfinx_contact.pack_circumradius_facet(mesh, facets)
-    contact = dolfinx_contact.cpp.Contact(ft, 1, 1, V._cpp_object)
+    contact = dolfinx_contact.cpp.Contact(ft, [1, 1], V._cpp_object)
     contact.set_quadrature_degree(2 * P + Q + 1)
     g_vec = contact.pack_gap_plane(0, -g)
     coeffs = np.hstack([coeffs, h_facets, g_vec])

--- a/python/tests/test_dolfinx_cuas.py
+++ b/python/tests/test_dolfinx_cuas.py
@@ -192,7 +192,7 @@ def test_contact_kernel(theta, gamma, dim, gap):
         coeffs = dolfinx_cuas.cpp.pack_coefficients(
             [u._cpp_object, mu2._cpp_object, lmbda2._cpp_object], integral_entities)
         h_facets = dolfinx_contact.pack_circumradius_facet(mesh, bottom_facets)
-        contact = dolfinx_contact.cpp.Contact(facet_marker, bottom_value, top_value, V._cpp_object)
+        contact = dolfinx_contact.cpp.Contact(facet_marker, [bottom_value, top_value], V._cpp_object)
         contact.set_quadrature_degree(q_deg)
         g_vec = contact.pack_gap_plane(0, g)
         coeffs = np.hstack([coeffs, h_facets, g_vec])

--- a/python/tests/test_projection.py
+++ b/python/tests/test_projection.py
@@ -74,9 +74,12 @@ def test_projection(q_deg, surf, dim):
     V = _fem.VectorFunctionSpace(mesh, ("CG", 1))
 
     # Create contact class, gap function and normals
-    contact = dolfinx_contact.cpp.Contact(facet_marker, surface_0_val, surface_1_val, V._cpp_object)
+    contact = dolfinx_contact.cpp.Contact(facet_marker, [surface_0_val, surface_1_val], V._cpp_object)
     contact.set_quadrature_degree(q_deg)
-    contact.create_distance_map(surf)
+    if surf == 0:
+        contact.create_distance_map(surf, 1)
+    else:
+        contact.create_distance_map(surf, 0)
     gap = contact.pack_gap(surf)
     normals = contact.pack_ny(surf, gap)
 


### PR DESCRIPTION
The contact class is simplified by using arrays instead of duplicate variables with _0 and _1.