### PR TITLE
add _facets_to_cells map and remove duplicate maps

### DIFF
--- a/cpp/Contact.hpp
+++ b/cpp/Contact.hpp
@@ -69,7 +69,7 @@ public:
 
     std::vector<std::int32_t> marked_facets(num_facets, 0);
     // mark which facets are in any of the facet lists
-    for (size_t s = 0; _facets.size(); ++s)
+    for (size_t s = 0; s < _facets.size(); ++s)
       for (size_t i = 0; i < _facets[s].size(); ++i)
       {
         std::int32_t facet = _facets[s][i];
@@ -848,7 +848,7 @@ public:
     {
       auto facet_pair = _facets_to_cells->links(puppet_facets[i]);
       auto cell = facet_pair[0]; // extract cell
-      const std::int32_t local_index = _facet_pair[1];
+      const std::int32_t local_index = facet_pair[1];
 
       // extract local dofs
       auto x_dofs = x_dofmap.links(cell);

--- a/python/dolfinx_contact/one_sided/nitsche_rigid_surface.py
+++ b/python/dolfinx_contact/one_sided/nitsche_rigid_surface.py
@@ -178,22 +178,20 @@ def nitsche_rigid_surface(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int
         for i in range(x.shape[1]):
             xi = x[:, i]
             facet = facets[i]
-            # FIXME: code crashes if the if statement is removed. Bug in compute_closes_entity.
-            if (np.argwhere(np.array(contact_facets) == facet)).shape[0] > 0:
-                # Compute distance between point and closest facet
-                index = np.argwhere(np.array(contact_facets) == facet)[0, 0]
-                facet_geometry = _cpp.mesh.entities_to_geometry(mesh, fdim, [facet], False)
-                coords0 = mesh_geometry[facet_geometry][0]
-                R = np.linalg.norm(_cpp.geometry.compute_distance_gjk(coords0, xi))
-                # If point on a facet in contact surface (i.e., if distance between point and closest
-                # facet is 0), use contact.facet_map(0) to find closest facet on rigid surface and
-                # compute distance vector
-                if np.isclose(R, 0):
-                    facet_2 = lookup.links(index)[0]
-                    facet2_geometry = _cpp.mesh.entities_to_geometry(mesh, fdim, [facet_2], False)
-                    coords = mesh_geometry[facet2_geometry][0]
-                    dist_vec = _cpp.geometry.compute_distance_gjk(coords, xi)
-                    dist_vec_array[: gdim, i] = dist_vec[: gdim]
+            # Compute distance between point and closest facet
+            index = np.argwhere(np.array(contact_facets) == facet)[0, 0]
+            facet_geometry = _cpp.mesh.entities_to_geometry(mesh, fdim, [facet], False)
+            coords0 = mesh_geometry[facet_geometry][0]
+            R = np.linalg.norm(_cpp.geometry.compute_distance_gjk(coords0, xi))
+            # If point on a facet in contact surface (i.e., if distance between point and closest
+            # facet is 0), use contact.facet_map(0) to find closest facet on rigid surface and
+            # compute distance vector
+            if np.isclose(R, 0):
+                facet_2 = lookup.links(index)[0]
+                facet2_geometry = _cpp.mesh.entities_to_geometry(mesh, fdim, [facet_2], False)
+                coords = mesh_geometry[facet2_geometry][0]
+                dist_vec = _cpp.geometry.compute_distance_gjk(coords, xi)
+                dist_vec_array[: gdim, i] = dist_vec[: gdim]
         return dist_vec_array
 
     # interpolate gap function


### PR DESCRIPTION
This pull request removes the following data structures:
_cell_facet_pairs 
_cell_maps 

Instead a new adjacency list _facets_to_cells is added that allows to easily access (cell, local_facet) for each facet on one of the surfaces.