### PR TITLE
add update_geometry and continue tidy up of utils.h

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -58,6 +58,7 @@ include(GNUInstallDirs)
 install(FILES Contact.hpp contact_kernels.hpp utils.h coefficients.h geometric_quantities.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx_contact COMPONENT Development)
 
 target_sources(dolfinx_contact PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/coefficients.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/geometric_quantities.cpp
   )

--- a/cpp/geometric_quantities.cpp
+++ b/cpp/geometric_quantities.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier:    MIT
 
 #include "geometric_quantities.h"
-#include "utils.h"
 #include <xtensor/xio.hpp>
 #include <xtensor/xmath.hpp>
 #include <xtensor/xnorm.hpp>

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Jørgen S. Dokken
+// Copyright (C) 2021 Jørgen S. Dokken and Sarah Roggendorf
 //
 // This file is part of DOLFINx_CONTACT
 //
@@ -6,3 +6,243 @@
 #include "utils.h"
 
 using namespace dolfinx_contact;
+
+//-----------------------------------------------------------------------------
+void dolfinx_contact::pull_back(xt::xtensor<double, 3>& J,
+                                xt::xtensor<double, 3>& K,
+                                xt::xtensor<double, 1>& detJ,
+                                const xt::xtensor<double, 2>& x,
+                                xt::xtensor<double, 2>& X,
+                                const xt::xtensor<double, 2>& coordinate_dofs,
+                                const dolfinx::fem::CoordinateElement& cmap)
+{
+  // number of points
+  const std::size_t num_points = x.shape(0);
+  assert(J.shape(0) >= num_points);
+  assert(K.shape(0) >= num_points);
+  assert(detJ.shape(0) >= num_points);
+
+  // Get mesh data from input
+  const size_t tdim = K.shape(1);
+
+  // -- Lambda function for affine pull-backs
+  auto pull_back_affine
+      = [&cmap, tdim,
+         X0 = xt::xtensor<double, 2>(xt::zeros<double>({std::size_t(1), tdim})),
+         data = xt::xtensor<double, 4>(cmap.tabulate_shape(1, 1)),
+         dphi = xt::xtensor<double, 2>({tdim, cmap.tabulate_shape(1, 1)[2]})](
+            auto&& X, const auto& cell_geometry, auto&& J, auto&& K,
+            const auto& x) mutable
+  {
+    cmap.tabulate(1, X0, data);
+    dphi = xt::view(data, xt::range(1, tdim + 1), 0, xt::all(), 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi, cell_geometry, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
+    cmap.pull_back_affine(X, K, cmap.x0(cell_geometry), x);
+  };
+
+  xt::xtensor<double, 2> dphi;
+
+  xt::xtensor<double, 4> phi(cmap.tabulate_shape(1, 1));
+  if (cmap.is_affine())
+  {
+    J.fill(0);
+    pull_back_affine(X, coordinate_dofs, xt::view(J, 0, xt::all(), xt::all()),
+                     xt::view(K, 0, xt::all(), xt::all()), x);
+    detJ[0] = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(
+        xt::view(J, 0, xt::all(), xt::all()));
+    for (std::size_t p = 1; p < num_points; ++p)
+    {
+      xt::view(J, p, xt::all(), xt::all())
+          = xt::view(J, 0, xt::all(), xt::all());
+      xt::view(K, p, xt::all(), xt::all())
+          = xt::view(K, 0, xt::all(), xt::all());
+      detJ[p] = detJ[0];
+    }
+  }
+  else
+  {
+    cmap.pull_back_nonaffine(X, x, coordinate_dofs);
+    cmap.tabulate(1, X, phi);
+    J.fill(0);
+    for (std::size_t p = 0; p < X.shape(0); ++p)
+    {
+      auto _J = xt::view(J, p, xt::all(), xt::all());
+      dphi = xt::view(phi, xt::range(1, tdim + 1), p, xt::all(), 0);
+      dolfinx::fem::CoordinateElement::compute_jacobian(dphi, coordinate_dofs,
+                                                        _J);
+      dolfinx::fem::CoordinateElement::compute_jacobian_inverse(
+          _J, xt::view(K, p, xt::all(), xt::all()));
+      detJ[p]
+          = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(_J);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 3> dolfinx_contact::get_basis_functions(
+    xt::xtensor<double, 3>& J, xt::xtensor<double, 3>& K,
+    xt::xtensor<double, 1>& detJ, const xt::xtensor<double, 2>& x,
+    const xt::xtensor<double, 2>& coordinate_dofs, const std::int32_t index,
+    const std::int32_t perm,
+    std::shared_ptr<const dolfinx::fem::FiniteElement> element,
+    const dolfinx::fem::CoordinateElement& cmap)
+{
+  // number of points
+  const std::size_t num_points = x.shape(0);
+  assert(J.shape(0) >= num_points);
+  assert(K.shape(0) >= num_points);
+  assert(detJ.shape(0) >= num_points);
+
+  // Get mesh data from input
+  const size_t tdim = K.shape(1);
+
+  // Get element data
+  const size_t block_size = element->block_size();
+  const size_t reference_value_size
+      = element->reference_value_size() / block_size;
+  const size_t value_size = element->value_size() / block_size;
+  const size_t space_dimension = element->space_dimension() / block_size;
+
+  xt::xtensor<double, 2> X({x.shape(0), tdim});
+
+  // Skip negative cell indices
+  xt::xtensor<double, 3> basis_array = xt::zeros<double>(
+      {num_points, space_dimension * block_size, value_size * block_size});
+  if (index < 0)
+    return basis_array;
+
+  pull_back(J, K, detJ, x, X, coordinate_dofs, cmap);
+  // Prepare basis function data structures
+  xt::xtensor<double, 4> tabulated_data(
+      {1, num_points, space_dimension, reference_value_size});
+  xt::xtensor<double, 3> basis_values(
+      {num_points, space_dimension, value_size});
+
+  // Get push forward function
+  xt::xtensor<double, 2> point_basis_values({space_dimension, value_size});
+  using u_t = xt::xview<decltype(basis_values)&, std::size_t,
+                        xt::xall<std::size_t>, xt::xall<std::size_t>>;
+  using U_t = xt::xview<decltype(point_basis_values)&, xt::xall<std::size_t>,
+                        xt::xall<std::size_t>>;
+  using J_t = xt::xview<decltype(J)&, std::size_t, xt::xall<std::size_t>,
+                        xt::xall<std::size_t>>;
+  using K_t = xt::xview<decltype(K)&, std::size_t, xt::xall<std::size_t>,
+                        xt::xall<std::size_t>>;
+  // FIXME: These should be moved out of this function
+  auto push_forward_fn = element->map_fn<u_t, U_t, J_t, K_t>();
+  const std::function<void(const xtl::span<PetscScalar>&,
+                           const xtl::span<const std::uint32_t>&, std::int32_t,
+                           int)>
+      transformation = element->get_dof_transformation_function<PetscScalar>();
+
+  // Compute basis on reference element
+  element->tabulate(tabulated_data, X, 0);
+  for (std::size_t q = 0; q < num_points; ++q)
+  {
+    // Permute the reference values to account for the cell's orientation
+    point_basis_values = xt::view(tabulated_data, 0, q, xt::all(), xt::all());
+    element->apply_dof_transformation(
+        xtl::span<double>(point_basis_values.data(), point_basis_values.size()),
+        perm, 1);
+    // Push basis forward to physical element
+    auto _J = xt::view(J, q, xt::all(), xt::all());
+    auto _K = xt::view(K, q, xt::all(), xt::all());
+    auto _u = xt::view(basis_values, q, xt::all(), xt::all());
+    auto _U = xt::view(point_basis_values, xt::all(), xt::all());
+    push_forward_fn(_u, _U, _J, detJ[q], _K);
+  }
+
+  // Expand basis values for each dof
+  for (std::size_t p = 0; p < num_points; ++p)
+  {
+    for (std::size_t block = 0; block < block_size; ++block)
+    {
+      for (std::size_t i = 0; i < space_dimension; ++i)
+      {
+        for (std::size_t j = 0; j < value_size; ++j)
+        {
+          basis_array(p, i * block_size + block, j * block_size + block)
+              = basis_values(p, i, j);
+        }
+      }
+    }
+  }
+  return basis_array;
+}
+
+//-----------------------------------------------------------------------------
+std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
+dolfinx_contact::sort_cells(const xtl::span<const std::int32_t>& cells,
+                            const xtl::span<std::int32_t>& perm)
+{
+  assert(perm.size() == cells.size());
+
+  const auto num_cells = (std::int32_t)cells.size();
+  std::vector<std::int32_t> unique_cells(num_cells);
+  std::vector<std::int32_t> offsets(num_cells + 1, 0);
+  std::iota(perm.begin(), perm.end(), 0);
+  dolfinx::argsort_radix<std::int32_t>(cells, perm);
+
+  // Sort cells in accending order
+  for (std::int32_t i = 0; i < num_cells; ++i)
+    unique_cells[i] = cells[perm[i]];
+
+  // Compute the number of identical cells
+  std::int32_t index = 0;
+  for (std::int32_t i = 0; i < num_cells - 1; ++i)
+    if (unique_cells[i] != unique_cells[i + 1])
+      offsets[++index] = i + 1;
+
+  offsets[index + 1] = num_cells;
+  unique_cells.erase(std::unique(unique_cells.begin(), unique_cells.end()),
+                     unique_cells.end());
+  offsets.resize(unique_cells.size() + 1);
+
+  return std::make_pair(unique_cells, offsets);
+}
+
+//-------------------------------------------------------------------------------------
+void dolfinx_contact::update_geometry(
+    const dolfinx::fem::Function<PetscScalar>& u,
+    std::shared_ptr<dolfinx::mesh::Mesh> mesh)
+{
+  auto V = u.function_space();
+  assert(V);
+  auto dofmap = V->dofmap();
+  assert(dofmap);
+  // Check that mesh to be updated and underlying mesh of u are the same
+  assert(mesh == V->mesh());
+
+  // The Function and the mesh must have identical element_dof_layouts
+  // (up to the block size)
+  assert(dofmap->element_dof_layout()
+         == mesh->geometry().cmap().create_dof_layout());
+
+  const int tdim = mesh->topology().dim();
+  auto cell_map = mesh->topology().index_map(tdim);
+  assert(cell_map);
+  const std::int32_t num_cells
+      = cell_map->size_local() + cell_map->num_ghosts();
+
+  // Get dof array and retrieve u at the mesh dofs
+  const dolfinx::graph::AdjacencyList<std::int32_t>& dofmap_x
+      = mesh->geometry().dofmap();
+  const int bs = dofmap->bs();
+  const auto& u_data = u.x()->array();
+  xtl::span<double> coords = mesh->geometry().x();
+  std::vector<double> dx(coords.size());
+  for (std::int32_t c = 0; c < num_cells; ++c)
+  {
+    auto dofs = dofmap->cell_dofs(c);
+    auto dofs_x = dofmap_x.links(c);
+    for (std::size_t i = 0; i < dofs.size(); ++i)
+      for (int j = 0; j < bs; ++j)
+      {
+        dx[3 * dofs_x[i] + j] = u_data[bs * dofs[i] + j];
+      }
+  }
+  // add u to mesh dofs
+  std::transform(coords.begin(), coords.end(), dx.begin(), coords.begin(),
+                 std::plus<double>());
+}

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Sarah Roggendorf
+// Copyright (C) 2021 Jørgen S. Dokken and Sarah Roggendorf
 //
 // This file is part of DOLFINx_CONTACT
 //
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "geometric_quantities.h"
 #include <basix/cell.h>
 #include <basix/finite-element.h>
 #include <basix/quadrature.h>
@@ -40,70 +39,8 @@ void pull_back(xt::xtensor<double, 3>& J, xt::xtensor<double, 3>& K,
                xt::xtensor<double, 1>& detJ, const xt::xtensor<double, 2>& x,
                xt::xtensor<double, 2>& X,
                const xt::xtensor<double, 2>& coordinate_dofs,
-               const dolfinx::fem::CoordinateElement& cmap)
-{
-  // number of points
-  const std::size_t num_points = x.shape(0);
-  assert(J.shape(0) >= num_points);
-  assert(K.shape(0) >= num_points);
-  assert(detJ.shape(0) >= num_points);
+               const dolfinx::fem::CoordinateElement& cmap);
 
-  // Get mesh data from input
-  const size_t tdim = K.shape(1);
-
-  // -- Lambda function for affine pull-backs
-  auto pull_back_affine
-      = [&cmap, tdim,
-         X0 = xt::xtensor<double, 2>(xt::zeros<double>({std::size_t(1), tdim})),
-         data = xt::xtensor<double, 4>(cmap.tabulate_shape(1, 1)),
-         dphi = xt::xtensor<double, 2>({tdim, cmap.tabulate_shape(1, 1)[2]})](
-            auto&& X, const auto& cell_geometry, auto&& J, auto&& K,
-            const auto& x) mutable
-  {
-    cmap.tabulate(1, X0, data);
-    dphi = xt::view(data, xt::range(1, tdim + 1), 0, xt::all(), 0);
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi, cell_geometry, J);
-    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
-    cmap.pull_back_affine(X, K, cmap.x0(cell_geometry), x);
-  };
-
-  xt::xtensor<double, 2> dphi;
-
-  xt::xtensor<double, 4> phi(cmap.tabulate_shape(1, 1));
-  if (cmap.is_affine())
-  {
-    J.fill(0);
-    pull_back_affine(X, coordinate_dofs, xt::view(J, 0, xt::all(), xt::all()),
-                     xt::view(K, 0, xt::all(), xt::all()), x);
-    detJ[0] = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(
-        xt::view(J, 0, xt::all(), xt::all()));
-    for (std::size_t p = 1; p < num_points; ++p)
-    {
-      xt::view(J, p, xt::all(), xt::all())
-          = xt::view(J, 0, xt::all(), xt::all());
-      xt::view(K, p, xt::all(), xt::all())
-          = xt::view(K, 0, xt::all(), xt::all());
-      detJ[p] = detJ[0];
-    }
-  }
-  else
-  {
-    cmap.pull_back_nonaffine(X, x, coordinate_dofs);
-    cmap.tabulate(1, X, phi);
-    J.fill(0);
-    for (std::size_t p = 0; p < X.shape(0); ++p)
-    {
-      auto _J = xt::view(J, p, xt::all(), xt::all());
-      dphi = xt::view(phi, xt::range(1, tdim + 1), p, xt::all(), 0);
-      dolfinx::fem::CoordinateElement::compute_jacobian(dphi, coordinate_dofs,
-                                                        _J);
-      dolfinx::fem::CoordinateElement::compute_jacobian_inverse(
-          _J, xt::view(K, p, xt::all(), xt::all()));
-      detJ[p]
-          = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(_J);
-    }
-  }
-}
 //-----------------------------------------------------------------------------
 /// This function computes the basis function values on a given cell at a
 /// given set of points
@@ -125,90 +62,7 @@ get_basis_functions(xt::xtensor<double, 3>& J, xt::xtensor<double, 3>& K,
                     const xt::xtensor<double, 2>& coordinate_dofs,
                     const std::int32_t index, const std::int32_t perm,
                     std::shared_ptr<const dolfinx::fem::FiniteElement> element,
-                    const dolfinx::fem::CoordinateElement& cmap)
-{
-  // number of points
-  const std::size_t num_points = x.shape(0);
-  assert(J.shape(0) >= num_points);
-  assert(K.shape(0) >= num_points);
-  assert(detJ.shape(0) >= num_points);
-
-  // Get mesh data from input
-  const size_t tdim = K.shape(1);
-
-  // Get element data
-  const size_t block_size = element->block_size();
-  const size_t reference_value_size
-      = element->reference_value_size() / block_size;
-  const size_t value_size = element->value_size() / block_size;
-  const size_t space_dimension = element->space_dimension() / block_size;
-
-  xt::xtensor<double, 2> X({x.shape(0), tdim});
-
-  // Skip negative cell indices
-  xt::xtensor<double, 3> basis_array = xt::zeros<double>(
-      {num_points, space_dimension * block_size, value_size * block_size});
-  if (index < 0)
-    return basis_array;
-
-  pull_back(J, K, detJ, x, X, coordinate_dofs, cmap);
-  // Prepare basis function data structures
-  xt::xtensor<double, 4> tabulated_data(
-      {1, num_points, space_dimension, reference_value_size});
-  xt::xtensor<double, 3> basis_values(
-      {num_points, space_dimension, value_size});
-
-  // Get push forward function
-  xt::xtensor<double, 2> point_basis_values({space_dimension, value_size});
-  using u_t = xt::xview<decltype(basis_values)&, std::size_t,
-                        xt::xall<std::size_t>, xt::xall<std::size_t>>;
-  using U_t = xt::xview<decltype(point_basis_values)&, xt::xall<std::size_t>,
-                        xt::xall<std::size_t>>;
-  using J_t = xt::xview<decltype(J)&, std::size_t, xt::xall<std::size_t>,
-                        xt::xall<std::size_t>>;
-  using K_t = xt::xview<decltype(K)&, std::size_t, xt::xall<std::size_t>,
-                        xt::xall<std::size_t>>;
-  // FIXME: These should be moved out of this function
-  auto push_forward_fn = element->map_fn<u_t, U_t, J_t, K_t>();
-  const std::function<void(const xtl::span<PetscScalar>&,
-                           const xtl::span<const std::uint32_t>&, std::int32_t,
-                           int)>
-      transformation = element->get_dof_transformation_function<PetscScalar>();
-
-  // Compute basis on reference element
-  element->tabulate(tabulated_data, X, 0);
-  for (std::size_t q = 0; q < num_points; ++q)
-  {
-    // Permute the reference values to account for the cell's orientation
-    point_basis_values = xt::view(tabulated_data, 0, q, xt::all(), xt::all());
-    element->apply_dof_transformation(
-        xtl::span<double>(point_basis_values.data(), point_basis_values.size()),
-        perm, 1);
-    // Push basis forward to physical element
-    auto _J = xt::view(J, q, xt::all(), xt::all());
-    auto _K = xt::view(K, q, xt::all(), xt::all());
-    auto _u = xt::view(basis_values, q, xt::all(), xt::all());
-    auto _U = xt::view(point_basis_values, xt::all(), xt::all());
-    push_forward_fn(_u, _U, _J, detJ[q], _K);
-  }
-
-  // Expand basis values for each dof
-  for (std::size_t p = 0; p < num_points; ++p)
-  {
-    for (std::size_t block = 0; block < block_size; ++block)
-    {
-      for (std::size_t i = 0; i < space_dimension; ++i)
-      {
-        for (std::size_t j = 0; j < value_size; ++j)
-        {
-          basis_array(p, i * block_size + block, j * block_size + block)
-              = basis_values(p, i, j);
-        }
-      }
-    }
-  }
-  return basis_array;
-}
+                    const dolfinx::fem::CoordinateElement& cmap);
 
 double R_plus(double x) { return 0.5 * (std::abs(x) + x); }
 double dR_plus(double x) { return double(x > 0); }
@@ -236,31 +90,11 @@ int sgn(T val)
 // perm[k] = 3.
 std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
 sort_cells(const xtl::span<const std::int32_t>& cells,
-           const xtl::span<std::int32_t>& perm)
-{
-  assert(perm.size() == cells.size());
+           const xtl::span<std::int32_t>& perm);
 
-  const auto num_cells = (std::int32_t)cells.size();
-  std::vector<std::int32_t> unique_cells(num_cells);
-  std::vector<std::int32_t> offsets(num_cells + 1, 0);
-  std::iota(perm.begin(), perm.end(), 0);
-  dolfinx::argsort_radix<std::int32_t>(cells, perm);
-
-  // Sort cells in accending order
-  for (std::int32_t i = 0; i < num_cells; ++i)
-    unique_cells[i] = cells[perm[i]];
-
-  // Compute the number of identical cells
-  std::int32_t index = 0;
-  for (std::int32_t i = 0; i < num_cells - 1; ++i)
-    if (unique_cells[i] != unique_cells[i + 1])
-      offsets[++index] = i + 1;
-
-  offsets[index + 1] = num_cells;
-  unique_cells.erase(std::unique(unique_cells.begin(), unique_cells.end()),
-                     unique_cells.end());
-  offsets.resize(unique_cells.size() + 1);
-
-  return std::make_pair(unique_cells, offsets);
-}
+/// @param[in] u: dolfinx function on function space base on basix element
+/// @param[in] mesh: mesh to be updated
+/// Adds perturbation u to mesh
+void update_geometry(const dolfinx::fem::Function<PetscScalar>& u,
+                     std::shared_ptr<dolfinx::mesh::Mesh> mesh);
 } // namespace dolfinx_contact

--- a/python/demos/gradual_loading.py
+++ b/python/demos/gradual_loading.py
@@ -9,6 +9,7 @@ from mpi4py import MPI
 from dolfinx_contact.meshing import (convert_mesh, create_circle_circle_mesh,
                                      create_circle_plane_mesh,
                                      create_sphere_plane_mesh)
+from dolfinx_contact import update_geometry
 from dolfinx_contact.one_sided.nitsche_rigid_surface_cuas import \
     nitsche_rigid_surface_cuas
 
@@ -198,10 +199,7 @@ if __name__ == "__main__":
             xdmf.write_function(u1)
 
         # Perturb mesh with solution displacement
-        delta_x = u1.compute_point_values()
-        if delta_x.shape[1] < 3:
-            delta_x = np.hstack([delta_x, np.zeros((delta_x.shape[0], 3 - delta_x.shape[1]))])
-        mesh.geometry.x[:] += delta_x
+        update_geometry(u1._cpp_object, mesh)
 
         # Accumulate displacements
         u.x.array[:] += u1.x.array[:]

--- a/python/demos/nitsche_unbiased_demo.py
+++ b/python/demos/nitsche_unbiased_demo.py
@@ -15,6 +15,7 @@ from dolfinx_contact.meshing import (convert_mesh, create_box_mesh_2D,
                                      create_circle_circle_mesh,
                                      create_circle_plane_mesh,
                                      create_sphere_plane_mesh)
+from dolfinx_contact import update_geometry
 from dolfinx_contact.unbiased.nitsche_unbiased import nitsche_unbiased
 
 if __name__ == "__main__":
@@ -275,10 +276,7 @@ if __name__ == "__main__":
             xdmf.write_function(u1)
 
         # Perturb mesh with solution displacement
-        delta_x = u1.compute_point_values()
-        if delta_x.shape[1] < 3:
-            delta_x = np.hstack([delta_x, np.zeros((delta_x.shape[0], 3 - delta_x.shape[1]))])
-        mesh.geometry.x[:] += delta_x
+        update_geometry(u1._cpp_object, mesh)
 
         # Accumulate displacements
         u.x.array[:] += u1.x.array[:]

--- a/python/dolfinx_contact/__init__.py
+++ b/python/dolfinx_contact/__init__.py
@@ -7,9 +7,8 @@
 # flake8: noqa
 
 
-from dolfinx_contact.cpp import Kernel, pack_circumradius_facet
-
+from dolfinx_contact.cpp import Kernel, pack_circumradius_facet, update_geometry
 from .helpers import epsilon, lame_parameters, sigma_func
 
 __all__ = ["lame_parameters", "epsilon", "sigma_func", "Kernel",
-           "pack_circumradius_facet"]
+           "pack_circumradius_facet", "update_geometry"]

--- a/python/dolfinx_contact/wrappers.cpp
+++ b/python/dolfinx_contact/wrappers.cpp
@@ -198,4 +198,7 @@ PYBIND11_MODULE(cpp, m)
           return dolfinx_wrappers::as_pyarray(std::move(coeffs),
                                               std::array{shape0, cstride});
         });
+  m.def("update_geometry", [](const dolfinx::fem::Function<PetscScalar>& u,
+                              std::shared_ptr<dolfinx::mesh::Mesh> mesh)
+        { dolfinx_contact::update_geometry(u, mesh); });
 }

--- a/python/tests/test_circumradius.py
+++ b/python/tests/test_circumradius.py
@@ -28,7 +28,7 @@ def test_circumradius(dim):
         u.interpolate(lambda x: (0.1 * (x[1] > 0.5), 0.1 * np.sin(2 * np.pi * x[2]), np.zeros(x.shape[1])))
     else:
         u.interpolate(lambda x: (0.1 * np.cos(x[1]) * (x[0] > 0.2), 0.1 * x[1] + 0.1 * np.sin(2 * np.pi * x[0])))
-    mesh.geometry.x[:, :mesh.geometry.dim] += u.compute_point_values()
+    dolfinx_contact.update_geometry(u._cpp_object, mesh)
 
     mesh.topology.create_connectivity(dim - 1, dim)
     f_to_c = mesh.topology.connectivity(dim - 1, dim)


### PR DESCRIPTION
This PR adds the function update_geometry to perturb a mesh by a function. The dofs of the mesh and the function have to agree. 
This fixes the issue caused by the removal of compute_point_values.

Some functions are moved to utils.cpp from utils.h