### PR TITLE
Various fixes to contact

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,11 +1,11 @@
 name: Run sonarcloud analysis
 on:
   push:
-   branches-ignore:
-      - '**'
-  #   branches:
-  #     - main
-  #     - dokken/*
+  #  branches-ignore:
+  #     - '**'
+    branches:
+      - main
+      - dokken/*
   # pull_request:
   #   branches:
   #     - main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,11 +1,11 @@
 name: Run sonarcloud analysis
 on:
   push:
-  #  branches-ignore:
-  #     - '**'
-    branches:
-      - main
-      - dokken/*
+   branches-ignore:
+      - '**'
+  #      branches:
+  #        - main
+  #        - dokken/*
   # pull_request:
   #   branches:
   #     - main

--- a/cpp/contact_kernels.hpp
+++ b/cpp/contact_kernels.hpp
@@ -11,7 +11,6 @@
 #include <dolfinx_contact/Contact.hpp>
 #include <dolfinx_cuas/QuadratureRule.hpp>
 #include <dolfinx_cuas/kernels.hpp>
-#include <dolfinx_cuas/math.hpp>
 #include <dolfinx_cuas/utils.hpp>
 
 namespace dolfinx_contact
@@ -174,8 +173,8 @@ dolfinx_cuas::kernel_fn<T> generate_contact_kernel(
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
     xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
 
-    dolfinx_cuas::math::compute_jacobian(dphi0_c, c_view, J);
-    dolfinx_cuas::math::compute_inv(J, K);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
 
     // Compute normal of physical facet using a normalized covariant Piola
     // transform n_phys = J^{-T} n_ref / ||J^{-T} n_ref|| See for instance
@@ -216,7 +215,8 @@ dolfinx_cuas::kernel_fn<T> generate_contact_kernel(
     xt::xtensor<double, 2> J_tot
         = xt::zeros<double>({J.shape(0), J_f.shape(1)});
     dolfinx::math::dot(J, J_f, J_tot);
-    double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J_tot));
+    double detJ = std::fabs(
+        dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot));
 
     const xt::xtensor<double, 3>& dphi_f = dphi[facet_index];
     const xt::xtensor<double, 2>& phi_f = phi[facet_index];
@@ -358,8 +358,8 @@ dolfinx_cuas::kernel_fn<T> generate_contact_kernel(
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
     xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
     auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
-    dolfinx_cuas::math::compute_jacobian(dphi0_c, c_view, J);
-    dolfinx_cuas::math::compute_inv(J, K);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
 
     // Compute normal of physical facet using a normalized covariant Piola
     // transform n_phys = J^{-T} n_ref / ||J^{-T} n_ref|| See for instance
@@ -404,7 +404,8 @@ dolfinx_cuas::kernel_fn<T> generate_contact_kernel(
     xt::xtensor<double, 2> J_tot
         = xt::zeros<double>({J.shape(0), J_f.shape(1)});
     dolfinx::math::dot(J, J_f, J_tot);
-    double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J_tot));
+    double detJ = std::fabs(
+        dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot));
 
     const xt::xtensor<double, 3>& dphi_f = dphi[facet_index];
     const xt::xtensor<double, 2>& phi_f = phi[facet_index];

--- a/python/dolfinx_contact/wrappers.cpp
+++ b/python/dolfinx_contact/wrappers.cpp
@@ -97,7 +97,6 @@ PYBIND11_MODULE(cpp, m)
              auto submesh_map = self.facet_map(mt);
              auto offsets = submesh_map->offsets();
              auto old_data = submesh_map->array();
-             auto num_facets = offsets.size() - 1;
              auto facet_map = self.submesh(self.opposite(mt)).facet_map();
              auto parent_cells = self.submesh(self.opposite(mt)).parent_cells();
              std::vector<std::int32_t> data(old_data.size());

--- a/python/tests/test_contact_kernels.py
+++ b/python/tests/test_contact_kernels.py
@@ -41,6 +41,7 @@ def test_vector_surface_kernel(dim, kernel_type, P, Q):
     facets = locate_entities_boundary(mesh, mesh.topology.dim - 1,
                                       lambda x: np.logical_or(np.isclose(x[0], 0.0),
                                                               np.isclose(x[0], 1.0)))
+    facets = np.sort(facets)
     values = np.ones(len(facets), dtype=np.int32)
     ft = MeshTags(mesh, mesh.topology.dim - 1, facets, values)
 
@@ -159,6 +160,7 @@ def test_matrix_surface_kernel(dim, kernel_type, P, Q):
     facets = dolfinx.mesh.locate_entities_boundary(mesh, mesh.topology.dim - 1,
                                                    lambda x: np.logical_or(np.isclose(x[0], 0.0),
                                                                            np.isclose(x[0], 1.0)))
+    facets = np.sort(facets)
     values = np.ones(len(facets), dtype=np.int32)
     ft = MeshTags(mesh, mesh.topology.dim - 1, facets, values)
 


### PR DESCRIPTION
- Removes `cuas_maths` as dependency
- Removes various unused variables
- Use radix_sort in favor of `std::sort`
- Fixing some missing namespaces on `graph`
- Change in assembly API (set_values now accept spans)
- Move declaration of some xtensors out of loop
