### PR TITLE
Reduce runtime of packing u by avoiding use of `eval`

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,11 +1,11 @@
 name: Run sonarcloud analysis
 on:
   push:
-   branches-ignore:
-     - '**'
-  #     branches:
-  #       - main
-  #       - dokken/*
+  #  branches-ignore:
+  #    - '**'
+    branches:
+      - main
+      - dokken/*
   # pull_request:
   #   branches:
   #     - main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,11 +1,11 @@
 name: Run sonarcloud analysis
 on:
   push:
-  #  branches-ignore:
-  #    - '**'
-    branches:
-      - main
-      - dokken/*
+    branches-ignore:
+     - '**'
+    # branches:
+    #   - main
+    #   - dokken/*
   # pull_request:
   #   branches:
   #     - main

--- a/cpp/Contact.h
+++ b/cpp/Contact.h
@@ -32,6 +32,207 @@ using mat_set_fn = const std::function<int(
     const xtl::span<const std::int32_t>&, const xtl::span<const std::int32_t>&,
     const xtl::span<const PetscScalar>&)>;
 
+namespace
+{
+
+//-----------------------------------------------------------------------------
+/// Get basis values (not unrolled for block size) for a set of points and
+/// corresponding cells.
+/// @param[in] V The function space
+/// @param[in] x The coordinates of the points. It has shape
+/// (num_points, 3).
+/// @param[in] cells An array of cell indices. cells[i] is the index
+/// of the cell that contains the point x(i). Negative cell indices
+/// can be passed, and the corresponding point will be ignored.
+/// @param[in,out] u The values at the points. Values are not computed
+/// for points with a negative cell index. This argument must be
+/// passed with the correct size.
+/// @returns basis values (not unrolled for block size) for each point. shape
+/// (num_points, number_of_dofs, value_size)
+xt::xtensor<double, 3>
+evaluate_basis_functions(const dolfinx::fem::FunctionSpace& V,
+                         const xt::xtensor<double, 2>& x,
+                         const xtl::span<const std::int32_t>& cells)
+{
+  if (x.shape(0) != cells.size())
+  {
+    throw std::runtime_error(
+        "Number of points and number of cells must be equal.");
+  }
+  // Get mesh
+  std::shared_ptr<const dolfinx::mesh::Mesh> mesh = V.mesh();
+  assert(mesh);
+  const std::size_t gdim = mesh->geometry().dim();
+  const std::size_t tdim = mesh->topology().dim();
+  auto map = mesh->topology().index_map((int)tdim);
+
+  // Get geometry data
+  const dolfinx::graph::AdjacencyList<std::int32_t>& x_dofmap
+      = mesh->geometry().dofmap();
+  // FIXME: Add proper interface for num coordinate dofs
+  const std::size_t num_dofs_g = x_dofmap.num_links(0);
+  xtl::span<const double> x_g = mesh->geometry().x();
+
+  // Get coordinate map
+  const dolfinx::fem::CoordinateElement& cmap = mesh->geometry().cmap();
+
+  // Get element
+  assert(V.element());
+  std::shared_ptr<const dolfinx::fem::FiniteElement> element = V.element();
+  assert(element);
+  const int bs_element = element->block_size();
+  const std::size_t reference_value_size
+      = element->reference_value_size() / bs_element;
+  const std::size_t value_size = element->value_size() / bs_element;
+  const std::size_t space_dimension = element->space_dimension() / bs_element;
+
+  // Return early if we have no points
+  xt::xtensor<double, 3> basis_values(
+      {x.shape(0), space_dimension, value_size});
+  if (x.shape(0) == 0)
+    return basis_values;
+
+  // If the space has sub elements, concatenate the evaluations on the sub
+  // elements
+  if (const int num_sub_elements = element->num_sub_elements();
+      num_sub_elements > 1 && num_sub_elements != bs_element)
+  {
+    throw std::runtime_error("Function::eval is not supported for mixed "
+                             "elements. Extract subspaces.");
+  }
+
+  // Get dofmap
+  std::shared_ptr<const dolfinx::fem::DofMap> dofmap = V.dofmap();
+  assert(dofmap);
+
+  xtl::span<const std::uint32_t> cell_info;
+  if (element->needs_dof_transformations())
+  {
+    mesh->topology_mutable().create_entity_permutations();
+    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+  }
+
+  xt::xtensor<double, 2> coordinate_dofs
+      = xt::zeros<double>({num_dofs_g, gdim});
+  xt::xtensor<double, 2> xp = xt::zeros<double>({std::size_t(1), gdim});
+
+  // -- Lambda function for affine pull-backs
+  xt::xtensor<double, 4> data(cmap.tabulate_shape(1, 1));
+  const xt::xtensor<double, 2> X0(xt::zeros<double>({std::size_t(1), tdim}));
+  cmap.tabulate(1, X0, data);
+  const xt::xtensor<double, 2> dphi_i
+      = xt::view(data, xt::range(1, tdim + 1), 0, xt::all(), 0);
+  auto pull_back_affine = [&dphi_i](auto&& X, const auto& cell_geometry,
+                                    auto&& J, auto&& K, const auto& x) mutable
+  {
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_i, cell_geometry, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
+    dolfinx::fem::CoordinateElement::pull_back_affine(
+        X, K, dolfinx::fem::CoordinateElement::x0(cell_geometry), x);
+  };
+
+  xt::xtensor<double, 2> dphi;
+  xt::xtensor<double, 2> X({x.shape(0), tdim});
+  xt::xtensor<double, 3> J = xt::zeros<double>({x.shape(0), gdim, tdim});
+  xt::xtensor<double, 3> K = xt::zeros<double>({x.shape(0), tdim, gdim});
+  xt::xtensor<double, 1> detJ = xt::zeros<double>({x.shape(0)});
+  xt::xtensor<double, 4> phi(cmap.tabulate_shape(1, 1));
+
+  xt::xtensor<double, 2> _Xp({1, tdim});
+  for (std::size_t p = 0; p < cells.size(); ++p)
+  {
+    const int cell_index = cells[p];
+
+    // Skip negative cell indices
+    if (cell_index < 0)
+      continue;
+
+    // Get cell geometry (coordinate dofs)
+    auto x_dofs = x_dofmap.links(cell_index);
+    for (std::size_t i = 0; i < num_dofs_g; ++i)
+    {
+      const int pos = 3 * x_dofs[i];
+      for (std::size_t j = 0; j < gdim; ++j)
+        coordinate_dofs(i, j) = x_g[pos + j];
+    }
+
+    for (std::size_t j = 0; j < gdim; ++j)
+      xp(0, j) = x(p, j);
+
+    auto _J = xt::view(J, p, xt::all(), xt::all());
+    auto _K = xt::view(K, p, xt::all(), xt::all());
+
+    // Compute reference coordinates X, and J, detJ and K
+    if (cmap.is_affine())
+    {
+      pull_back_affine(_Xp, coordinate_dofs, _J, _K, xp);
+      detJ[p]
+          = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(_J);
+    }
+    else
+    {
+      cmap.pull_back_nonaffine(_Xp, xp, coordinate_dofs);
+      cmap.tabulate(1, _Xp, phi);
+      dphi = xt::view(phi, xt::range(1, tdim + 1), 0, xt::all(), 0);
+      J.fill(0);
+      dolfinx::fem::CoordinateElement::compute_jacobian(dphi, coordinate_dofs,
+                                                        _J);
+      dolfinx::fem::CoordinateElement::compute_jacobian_inverse(_J, _K);
+      detJ[p]
+          = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(_J);
+    }
+    xt::row(X, p) = xt::row(_Xp, 9);
+  }
+
+  // Prepare basis function data structures
+  xt::xtensor<double, 4> basis_reference_values(
+      {1, x.shape(0), space_dimension, reference_value_size});
+
+  // Compute basis on reference element
+  element->tabulate(basis_reference_values, X, 0);
+
+  using u_t = xt::xview<decltype(basis_values)&, std::size_t,
+                        xt::xall<std::size_t>, xt::xall<std::size_t>>;
+  using U_t
+      = xt::xview<decltype(basis_reference_values)&, std::size_t, std::size_t,
+                  xt::xall<std::size_t>, xt::xall<std::size_t>>;
+  using J_t = xt::xview<decltype(J)&, std::size_t, xt::xall<std::size_t>,
+                        xt::xall<std::size_t>>;
+  using K_t = xt::xview<decltype(K)&, std::size_t, xt::xall<std::size_t>,
+                        xt::xall<std::size_t>>;
+  auto push_forward_fn = element->map_fn<u_t, U_t, J_t, K_t>();
+  const std::function<void(const xtl::span<double>&,
+                           const xtl::span<const std::uint32_t>&, std::int32_t,
+                           int)>
+      apply_dof_transformation
+      = element->get_dof_transformation_function<double>();
+  const std::size_t num_basis_values = space_dimension * reference_value_size;
+  for (std::size_t p = 0; p < cells.size(); ++p)
+  {
+    const int cell_index = cells[p];
+
+    // Skip negative cell indices
+    if (cell_index < 0)
+      continue;
+
+    // Permute the reference values to account for the cell's orientation
+    apply_dof_transformation(
+        xtl::span(basis_reference_values.data() + p * num_basis_values,
+                  num_basis_values),
+        cell_info, cell_index, (int)reference_value_size);
+
+    // Push basis forward to physical element
+    auto _K = xt::view(K, p, xt::all(), xt::all());
+    auto _J = xt::view(J, p, xt::all(), xt::all());
+    auto _u = xt::view(basis_values, p, xt::all(), xt::all());
+    auto _U = xt::view(basis_reference_values, (std::size_t)0, p, xt::all(),
+                       xt::all());
+    push_forward_fn(_u, _U, _J, detJ[p], _K);
+  }
+  return basis_values;
+};
+} // namespace
+
 namespace dolfinx_contact
 {
 enum class Kernel
@@ -944,7 +1145,7 @@ public:
     auto submesh = _submeshes[_opposites[origin_meshtag]];
     auto mesh = submesh.mesh();                      // mesh
     const std::size_t gdim = mesh->geometry().dim(); // geometrical dimension
-    const std::size_t bs = _V->element()->block_size();
+    const std::size_t bs_element = _V->element()->block_size();
 
     // Select which side of the contact interface to loop from and get the
     // correct map
@@ -953,17 +1154,19 @@ public:
     auto facet_map = submesh.facet_map();
     const std::size_t num_facets = _cell_facet_pairs[origin_meshtag].size();
     const std::size_t num_q_points = _qp_ref_facet[0].shape(0);
-    std::vector<PetscScalar> c(num_facets * num_q_points * bs, 0.0);
-    const int cstride = num_q_points * bs;
     auto V_sub = std::make_shared<dolfinx::fem::FunctionSpace>(
         submesh.create_functionspace(_V));
     auto u_sub = dolfinx::fem::Function<PetscScalar>(V_sub);
-    submesh.copy_function(*u, u_sub);
+    auto sub_dofmap = V_sub->dofmap();
+    assert(sub_dofmap);
+    const int bs_dof = sub_dofmap->bs();
 
-    xt::xtensor<double, 2> points = xt::zeros<double>({num_q_points, gdim});
-    std::vector<std::int32_t> cells(num_q_points, 0);
-    xt::xtensor<PetscScalar, 2> vals
-        = xt::zeros<PetscScalar>({num_q_points, bs});
+    // dolfinx::common::Timer t("~~~Contact: copy u");
+    submesh.copy_function(*u, u_sub);
+    // t.stop();
+    xt::xtensor<double, 2> points
+        = xt::zeros<double>({num_facets * num_q_points, gdim});
+    std::vector<std::int32_t> cells(num_facets * num_q_points, -1);
     for (std::size_t i = 0; i < num_facets; ++i)
     {
       auto links = map->links(i);
@@ -972,31 +1175,59 @@ public:
       {
         for (std::size_t j = 0; j < gdim; ++j)
         {
-          points(q, j)
+          points(i * num_q_points + q, j)
               = qp_phys[i](q, j) + gap[i * gdim * num_q_points + q * gdim + j];
           auto linked_pair = facet_map->links(links[q]);
-          cells[q] = linked_pair[0];
-        }
-      }
-      vals.fill(0);
-      u_sub.eval(points, cells, vals);
-      for (std::size_t q = 0; q < num_q_points; ++q)
-      {
-        for (std::size_t j = 0; j < bs; ++j)
-        {
-          c[i * cstride + q * bs + j] = vals(q, j);
+          cells[i * num_q_points + q] = linked_pair[0];
         }
       }
     }
+    xt::xtensor<double, 3> basis_values
+        = evaluate_basis_functions(*u_sub.function_space(), points, cells);
+    const xtl::span<const PetscScalar>& u_coeffs = u_sub.x()->array();
 
+    // Output vector
+    std::vector<PetscScalar> c(num_facets * num_q_points * bs_element, 0.0);
+
+    // Create work vector for expansion coefficients
+    const int cstride = (int)num_q_points * bs_element;
+    const std::size_t num_basis_functions = basis_values.shape(1);
+    const std::size_t value_size = basis_values.shape(2);
+    std::vector<PetscScalar> coefficients(num_basis_functions * bs_element);
+    for (std::size_t i = 0; i < num_facets; ++i)
+    {
+      for (std::size_t q = 0; q < num_q_points; ++q)
+      {
+        // Get degrees of freedom for current cell
+        xtl::span<const std::int32_t> dofs
+            = sub_dofmap->cell_dofs(cells[i * num_q_points + q]);
+        for (std::size_t j = 0; j < dofs.size(); ++j)
+          for (int k = 0; k < bs_dof; ++k)
+            coefficients[bs_dof * j + k] = u_coeffs[bs_dof * dofs[j] + k];
+
+        // Compute expansion
+        for (std::size_t k = 0; k < bs_element; ++k)
+        {
+          for (std::size_t l = 0; l < num_basis_functions; ++l)
+          {
+            for (std::size_t m = 0; m < value_size; ++m)
+            {
+              c[cstride + q * (num_basis_functions * bs_element)
+                + l * bs_element + k]
+                  += coefficients[bs_element * l + k] * basis_values(0, l, m);
+            }
+          }
+        }
+      }
+    }
     return {std::move(c), cstride};
   }
 
   /// Compute inward surface normal at Pi(x)
   /// @param[in] orgin_meshtag - surface on which to integrate
-  /// @param[in] gap - gap function: Pi(x)-x packed at quadrature points, where
-  /// Pi(x) is the chosen projection of x onto the contact surface of the body
-  /// coming into contact
+  /// @param[in] gap - gap function: Pi(x)-x packed at quadrature points,
+  /// where Pi(x) is the chosen projection of x onto the contact surface of
+  /// the body coming into contact
   /// @param[out] c - normals ny packed on facets.
   std::pair<std::vector<PetscScalar>, int>
   pack_ny(int origin_meshtag, const xtl::span<const PetscScalar> gap)
@@ -1140,14 +1371,14 @@ private:
   // store index of candidate_surface for each puppet_surface
   std::array<int, 2> _opposites = {0, 0};
   std::shared_ptr<dolfinx::fem::FunctionSpace> _V; // Function space
-  // _facets_maps[i] = adjacency list of closest facet on candidate surface for
-  // every quadrature point in _qp_phys[i] (quadrature points on every facet of
-  // ith surface)
+  // _facets_maps[i] = adjacency list of closest facet on candidate surface
+  // for every quadrature point in _qp_phys[i] (quadrature points on every
+  // facet of ith surface)
   std::array<std::shared_ptr<const dolfinx::graph::AdjacencyList<std::int32_t>>,
              2>
       _facet_maps;
-  //  _qp_phys[i] contains the quadrature points on the physical facets for each
-  //  facet on ith surface in _surfaces
+  //  _qp_phys[i] contains the quadrature points on the physical facets for
+  //  each facet on ith surface in _surfaces
   std::array<std::vector<xt::xtensor<double, 2>>, 2> _qp_phys;
   // quadrature points on reference facet
   std::vector<xt::xarray<double>> _qp_ref_facet;

--- a/cpp/Contact.h
+++ b/cpp/Contact.h
@@ -23,8 +23,6 @@
 #include <dolfinx_cuas/utils.hpp>
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xindex_view.hpp>
-#include <xtensor/xio.hpp>
-#include <xtl/xspan.hpp>
 using contact_kernel_fn = std::function<void(
     std::vector<std::vector<PetscScalar>>&, const double*, const double*,
     const double*, const int*, const std::uint8_t*, const std::size_t)>;

--- a/cpp/Contact.h
+++ b/cpp/Contact.h
@@ -1141,7 +1141,7 @@ public:
                  std::shared_ptr<dolfinx::fem::Function<PetscScalar>> u,
                  const xtl::span<const PetscScalar> gap)
   {
-
+    dolfinx::common::Timer t("Pack contact u");
     // Mesh info
     auto submesh = _submeshes[_opposites[origin_meshtag]];
     auto mesh = submesh.mesh();                      // mesh
@@ -1222,6 +1222,7 @@ public:
         }
       }
     }
+    t.stop();
     return {std::move(c), cstride};
   }
 

--- a/cpp/Contact.h
+++ b/cpp/Contact.h
@@ -987,14 +987,8 @@ public:
         }
       }
 
-      dolfinx::common::Timer ttt("~~Old eval");
-      xt::xtensor<double, 2> u_vals({num_facets * num_q_points, gdim});
-      u_sub.eval(points, cells, u_vals);
-      ttt.stop();
-      dolfinx::common::Timer tt("~~New eval");
       evaluate_basis_functions(*u_sub.function_space(), points, cells,
                                basis_values);
-      tt.stop();
     }
 
     const xtl::span<const PetscScalar>& u_coeffs = u_sub.x()->array();

--- a/cpp/Contact.h
+++ b/cpp/Contact.h
@@ -21,7 +21,9 @@
 #include <dolfinx/mesh/cell_types.h>
 #include <dolfinx_cuas/QuadratureRule.hpp>
 #include <dolfinx_cuas/utils.hpp>
+#include <xtensor/xadapt.hpp>
 #include <xtensor/xindex_view.hpp>
+#include <xtensor/xio.hpp>
 #include <xtl/xspan.hpp>
 using contact_kernel_fn = std::function<void(
     std::vector<std::vector<PetscScalar>>&, const double*, const double*,
@@ -1190,6 +1192,7 @@ public:
     std::vector<PetscScalar> c(num_facets * num_q_points * bs_element, 0.0);
 
     // Create work vector for expansion coefficients
+    const int cstride = (int)num_q_points * bs_element;
     const std::size_t num_basis_functions = basis_values.shape(1);
     const std::size_t value_size = basis_values.shape(2);
     std::vector<PetscScalar> coefficients(num_basis_functions * bs_element);
@@ -1211,7 +1214,7 @@ public:
           {
             for (std::size_t m = 0; m < value_size; ++m)
             {
-              c[num_q_points * i + q * bs_element + k]
+              c[cstride * i + q * bs_element + k]
                   += coefficients[bs_element * l + k]
                      * basis_values(num_q_points * i + q, l, m);
             }
@@ -1219,7 +1222,6 @@ public:
         }
       }
     }
-    const int cstride = (int)num_q_points * bs_element;
     return {std::move(c), cstride};
   }
 

--- a/cpp/Contact.h
+++ b/cpp/Contact.h
@@ -776,7 +776,7 @@ public:
 
     // Pack gap function for each quadrature point on each facet
     std::vector<PetscScalar> c(num_facets * num_q_point * gdim, 0.0);
-    const int cstride = (int)num_q_point * gdim;
+    const auto cstride = (int)num_q_point * gdim;
     xt::xtensor<double, 2> point = {{0, 0, 0}};
 
     for (std::size_t i = 0; i < num_facets; ++i)
@@ -851,7 +851,7 @@ public:
     const std::int32_t ndofs = _V->dofmap()->cell_dofs(0).size();
     std::vector<PetscScalar> c(
         num_facets * num_q_points * max_links * ndofs * bs, 0.0);
-    const int cstride = num_q_points * max_links * ndofs * bs;
+    const auto cstride = int(num_q_points * max_links * ndofs * bs);
     xt::xtensor<double, 2> q_points
         = xt::zeros<double>({std::size_t(num_q_points), std::size_t(gdim)});
     xt::xtensor<double, 2> dphi;
@@ -902,11 +902,11 @@ public:
         const std::size_t num_dofs_g = x_dofs.size();
         xt::xtensor<double, 2> coordinate_dofs
             = xt::zeros<double>({num_dofs_g, std::size_t(gdim)});
-        for (std::size_t i = 0; i < num_dofs_g; ++i)
+        for (std::size_t k = 0; k < num_dofs_g; ++k)
         {
 
-          std::copy_n(std::next(mesh_geometry.begin(), 3 * x_dofs[i]), gdim,
-                      std::next(coordinate_dofs.begin(), i * gdim));
+          std::copy_n(std::next(mesh_geometry.begin(), 3 * x_dofs[k]), gdim,
+                      std::next(coordinate_dofs.begin(), k * gdim));
         }
         // Extract all physical points Pi(x) on a facet of linked_cell
         auto qp = xt::view(q_points, xt::keep(indices), xt::all());
@@ -997,7 +997,7 @@ public:
     std::vector<PetscScalar> c(num_facets * num_q_points * bs_element, 0.0);
 
     // Create work vector for expansion coefficients
-    const int cstride = int(num_q_points * bs_element);
+    const auto cstride = int(num_q_points * bs_element);
     const std::size_t num_basis_functions = basis_values.shape(1);
     const std::size_t value_size = basis_values.shape(2);
     std::vector<PetscScalar> coefficients(num_basis_functions * bs_element);
@@ -1061,7 +1061,7 @@ public:
     const std::size_t num_facets = _cell_facet_pairs[origin_meshtag].size();
     const std::size_t num_q_points = _qp_ref_facet[0].shape(0);
     std::vector<PetscScalar> c(num_facets * num_q_points * gdim, 0.0);
-    const int cstride = (int)num_q_points * gdim;
+    const auto cstride = (int)num_q_points * gdim;
     xt::xtensor<double, 2> point = xt::zeros<double>(
         {std::size_t(1), std::size_t(gdim)}); // To store Pi(x)
 
@@ -1162,7 +1162,7 @@ public:
     // FIXME: This does not work for prism meshes
     std::size_t num_q_point = _qp_ref_facet[0].shape(0);
     std::vector<PetscScalar> c(num_facets * num_q_point * gdim, 0.0);
-    const int cstride = (int)num_q_point * gdim;
+    const auto cstride = (int)num_q_point * gdim;
     for (std::size_t i = 0; i < num_facets; i++)
     {
       int offset = (int)i * cstride;

--- a/cpp/coefficients.cpp
+++ b/cpp/coefficients.cpp
@@ -359,6 +359,5 @@ std::pair<std::vector<PetscScalar>, int> dolfinx_contact::pack_circumradius(
     circumradius.push_back(
         compute_circumradius(mesh, detJ[0], coordinate_dofs));
   }
-  const int cstride = 1;
-  return {std::move(circumradius), cstride};
+  return {std::move(circumradius), 1};
 }

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -250,3 +250,185 @@ void dolfinx_contact::update_geometry(
 double dolfinx_contact::R_plus(double x) { return 0.5 * (std::abs(x) + x); }
 //-------------------------------------------------------------------------------------
 double dolfinx_contact::dR_plus(double x) { return double(x > 0); }
+//-----------------------------------------------------------------------------
+xt::xtensor<double, 3> dolfinx_contact::evaluate_basis_functions(
+    const dolfinx::fem::FunctionSpace& V, const xt::xtensor<double, 2>& x,
+    const xtl::span<const std::int32_t>& cells)
+{
+  if (x.shape(0) != cells.size())
+  {
+    throw std::runtime_error(
+        "Number of points and number of cells must be equal.");
+  }
+  // Get mesh
+  std::shared_ptr<const dolfinx::mesh::Mesh> mesh = V.mesh();
+  assert(mesh);
+  const std::size_t gdim = mesh->geometry().dim();
+  const std::size_t tdim = mesh->topology().dim();
+  auto map = mesh->topology().index_map((int)tdim);
+
+  // Get geometry data
+  const dolfinx::graph::AdjacencyList<std::int32_t>& x_dofmap
+      = mesh->geometry().dofmap();
+  // FIXME: Add proper interface for num coordinate dofs
+  const std::size_t num_dofs_g = x_dofmap.num_links(0);
+  xtl::span<const double> x_g = mesh->geometry().x();
+
+  // Get coordinate map
+  const dolfinx::fem::CoordinateElement& cmap = mesh->geometry().cmap();
+
+  // Get element
+  assert(V.element());
+  std::shared_ptr<const dolfinx::fem::FiniteElement> element = V.element();
+  assert(element);
+  const int bs_element = element->block_size();
+  const std::size_t reference_value_size
+      = element->reference_value_size() / bs_element;
+  const std::size_t value_size = element->value_size() / bs_element;
+  const std::size_t space_dimension = element->space_dimension() / bs_element;
+
+  // Return early if we have no points
+  xt::xtensor<double, 3> basis_values(
+      {x.shape(0), space_dimension, value_size});
+  if (x.shape(0) == 0)
+    return basis_values;
+
+  // If the space has sub elements, concatenate the evaluations on the sub
+  // elements
+  if (const int num_sub_elements = element->num_sub_elements();
+      num_sub_elements > 1 && num_sub_elements != bs_element)
+  {
+    throw std::runtime_error("Function::eval is not supported for mixed "
+                             "elements. Extract subspaces.");
+  }
+
+  // Get dofmap
+  std::shared_ptr<const dolfinx::fem::DofMap> dofmap = V.dofmap();
+  assert(dofmap);
+
+  xtl::span<const std::uint32_t> cell_info;
+  if (element->needs_dof_transformations())
+  {
+    mesh->topology_mutable().create_entity_permutations();
+    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+  }
+
+  xt::xtensor<double, 2> coordinate_dofs
+      = xt::zeros<double>({num_dofs_g, gdim});
+  xt::xtensor<double, 2> xp = xt::zeros<double>({std::size_t(1), gdim});
+
+  // -- Lambda function for affine pull-backs
+  xt::xtensor<double, 4> data(cmap.tabulate_shape(1, 1));
+  const xt::xtensor<double, 2> X0(xt::zeros<double>({std::size_t(1), tdim}));
+  cmap.tabulate(1, X0, data);
+  const xt::xtensor<double, 2> dphi_i
+      = xt::view(data, xt::range(1, tdim + 1), 0, xt::all(), 0);
+  auto pull_back_affine = [&dphi_i](auto&& X, const auto& cell_geometry,
+                                    auto&& J, auto&& K, const auto& x) mutable
+  {
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_i, cell_geometry, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
+    dolfinx::fem::CoordinateElement::pull_back_affine(
+        X, K, dolfinx::fem::CoordinateElement::x0(cell_geometry), x);
+  };
+
+  xt::xtensor<double, 2> dphi;
+  xt::xtensor<double, 2> X({x.shape(0), tdim});
+  xt::xtensor<double, 3> J = xt::zeros<double>({x.shape(0), gdim, tdim});
+  xt::xtensor<double, 3> K = xt::zeros<double>({x.shape(0), tdim, gdim});
+  xt::xtensor<double, 1> detJ = xt::zeros<double>({x.shape(0)});
+  xt::xtensor<double, 4> phi(cmap.tabulate_shape(1, 1));
+
+  xt::xtensor<double, 2> _Xp({1, tdim});
+  for (std::size_t p = 0; p < cells.size(); ++p)
+  {
+    const int cell_index = cells[p];
+
+    // Skip negative cell indices
+    if (cell_index < 0)
+      continue;
+
+    // Get cell geometry (coordinate dofs)
+    auto x_dofs = x_dofmap.links(cell_index);
+    for (std::size_t i = 0; i < num_dofs_g; ++i)
+    {
+      const int pos = 3 * x_dofs[i];
+      for (std::size_t j = 0; j < gdim; ++j)
+        coordinate_dofs(i, j) = x_g[pos + j];
+    }
+
+    for (std::size_t j = 0; j < gdim; ++j)
+      xp(0, j) = x(p, j);
+
+    auto _J = xt::view(J, p, xt::all(), xt::all());
+    auto _K = xt::view(K, p, xt::all(), xt::all());
+
+    // Compute reference coordinates X, and J, detJ and K
+    if (cmap.is_affine())
+    {
+      pull_back_affine(_Xp, coordinate_dofs, _J, _K, xp);
+      detJ[p]
+          = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(_J);
+    }
+    else
+    {
+      cmap.pull_back_nonaffine(_Xp, xp, coordinate_dofs);
+      cmap.tabulate(1, _Xp, phi);
+      dphi = xt::view(phi, xt::range(1, tdim + 1), 0, xt::all(), 0);
+      J.fill(0);
+      dolfinx::fem::CoordinateElement::compute_jacobian(dphi, coordinate_dofs,
+                                                        _J);
+      dolfinx::fem::CoordinateElement::compute_jacobian_inverse(_J, _K);
+      detJ[p]
+          = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(_J);
+    }
+    xt::row(X, p) = xt::row(_Xp, 9);
+  }
+
+  // Prepare basis function data structures
+  xt::xtensor<double, 4> basis_reference_values(
+      {1, x.shape(0), space_dimension, reference_value_size});
+
+  // Compute basis on reference element
+  element->tabulate(basis_reference_values, X, 0);
+
+  using u_t = xt::xview<decltype(basis_values)&, std::size_t,
+                        xt::xall<std::size_t>, xt::xall<std::size_t>>;
+  using U_t
+      = xt::xview<decltype(basis_reference_values)&, std::size_t, std::size_t,
+                  xt::xall<std::size_t>, xt::xall<std::size_t>>;
+  using J_t = xt::xview<decltype(J)&, std::size_t, xt::xall<std::size_t>,
+                        xt::xall<std::size_t>>;
+  using K_t = xt::xview<decltype(K)&, std::size_t, xt::xall<std::size_t>,
+                        xt::xall<std::size_t>>;
+  auto push_forward_fn = element->map_fn<u_t, U_t, J_t, K_t>();
+  const std::function<void(const xtl::span<double>&,
+                           const xtl::span<const std::uint32_t>&, std::int32_t,
+                           int)>
+      apply_dof_transformation
+      = element->get_dof_transformation_function<double>();
+  const std::size_t num_basis_values = space_dimension * reference_value_size;
+  for (std::size_t p = 0; p < cells.size(); ++p)
+  {
+    const int cell_index = cells[p];
+
+    // Skip negative cell indices
+    if (cell_index < 0)
+      continue;
+
+    // Permute the reference values to account for the cell's orientation
+    apply_dof_transformation(
+        xtl::span(basis_reference_values.data() + p * num_basis_values,
+                  num_basis_values),
+        cell_info, cell_index, (int)reference_value_size);
+
+    // Push basis forward to physical element
+    auto _K = xt::view(K, p, xt::all(), xt::all());
+    auto _J = xt::view(J, p, xt::all(), xt::all());
+    auto _u = xt::view(basis_values, p, xt::all(), xt::all());
+    auto _U = xt::view(basis_reference_values, (std::size_t)0, p, xt::all(),
+                       xt::all());
+    push_forward_fn(_u, _U, _J, detJ[p], _K);
+  }
+  return basis_values;
+};

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -93,4 +93,23 @@ double R_plus(double x);
 /// Compute the derivative of the positive restriction (i.e.) the step function.
 /// @note Evaluates to 0 at x=0
 double dR_plus(double x);
+
+/// Get basis values (not unrolled for block size) for a set of points and
+/// corresponding cells.
+/// @param[in] V The function space
+/// @param[in] x The coordinates of the points. It has shape
+/// (num_points, 3).
+/// @param[in] cells An array of cell indices. cells[i] is the index
+/// of the cell that contains the point x(i). Negative cell indices
+/// can be passed, and the corresponding point will be ignored.
+/// @param[in,out] u The values at the points. Values are not computed
+/// for points with a negative cell index. This argument must be
+/// passed with the correct size.
+/// @returns basis values (not unrolled for block size) for each point. shape
+/// (num_points, number_of_dofs, value_size)
+xt::xtensor<double, 3>
+evaluate_basis_functions(const dolfinx::fem::FunctionSpace& V,
+                         const xt::xtensor<double, 2>& x,
+                         const xtl::span<const std::int32_t>& cells);
+
 } // namespace dolfinx_contact

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -94,6 +94,12 @@ double R_plus(double x);
 /// @note Evaluates to 0 at x=0
 double dR_plus(double x);
 
+/// Get shape of in,out variable for filling basis functions in for
+/// evaluate_basis_functions
+std::array<std::size_t, 3>
+evaulate_basis_shape(const dolfinx::fem::FunctionSpace& V,
+                     const std::size_t num_points);
+
 /// Get basis values (not unrolled for block size) for a set of points and
 /// corresponding cells.
 /// @param[in] V The function space
@@ -102,14 +108,12 @@ double dR_plus(double x);
 /// @param[in] cells An array of cell indices. cells[i] is the index
 /// of the cell that contains the point x(i). Negative cell indices
 /// can be passed, and the corresponding point will be ignored.
-/// @param[in,out] u The values at the points. Values are not computed
-/// for points with a negative cell index. This argument must be
-/// passed with the correct size.
-/// @returns basis values (not unrolled for block size) for each point. shape
-/// (num_points, number_of_dofs, value_size)
-xt::xtensor<double, 3>
-evaluate_basis_functions(const dolfinx::fem::FunctionSpace& V,
-                         const xt::xtensor<double, 2>& x,
-                         const xtl::span<const std::int32_t>& cells);
+/// @param[in,out] basis_values The values at the points. Values are not
+/// computed for points with a negative cell index. This argument must be passed
+/// with the correct size (num_points, number_of_dofs, value_size).
+void evaluate_basis_functions(const dolfinx::fem::FunctionSpace& V,
+                              const xt::xtensor<double, 2>& x,
+                              const xtl::span<const std::int32_t>& cells,
+                              xt::xtensor<double, 3>& basis_values);
 
 } // namespace dolfinx_contact

--- a/python/demos/compare_cuas_snes_one_sided.py
+++ b/python/demos/compare_cuas_snes_one_sided.py
@@ -11,8 +11,8 @@ import ufl
 from dolfinx.common import timing
 from dolfinx.fem import Function, assemble_scalar, form
 from dolfinx.io import XDMFFile
-from dolfinx.mesh import (MeshTags, create_unit_cube, create_unit_square,
-                          locate_entities_boundary, refine)
+from dolfinx.mesh import (create_unit_cube, create_unit_square,
+                          locate_entities_boundary, meshtags, refine)
 from mpi4py import MPI
 
 from dolfinx_contact.meshing import (convert_mesh, create_disk_mesh,
@@ -132,7 +132,7 @@ if __name__ == "__main__":
         indices = np.concatenate([top_facets, bottom_facets])
         values = np.hstack([top_values, bottom_values])
         sorted_facets = np.argsort(indices)
-        facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+        facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         mesh_data = (facet_marker, top_value, bottom_value)
 
         # Solve contact problem using Nitsche's method

--- a/python/demos/compare_nitsche_snes.py
+++ b/python/demos/compare_nitsche_snes.py
@@ -11,12 +11,13 @@ import ufl
 from dolfinx.common import timing
 from dolfinx.fem import assemble_scalar, form
 from dolfinx.io import XDMFFile
-from dolfinx.mesh import create_unit_cube, create_unit_square, MeshTags, locate_entities_boundary, refine
+from dolfinx.mesh import (create_unit_cube, create_unit_square,
+                          locate_entities_boundary, meshtags, refine)
+from mpi4py import MPI
+
 from dolfinx_contact.meshing import (convert_mesh, create_disk_mesh,
                                      create_sphere_mesh)
-from dolfinx_contact.one_sided import nitsche_ufl
-from dolfinx_contact.one_sided import snes_solver
-from mpi4py import MPI
+from dolfinx_contact.one_sided import nitsche_ufl, snes_solver
 
 if __name__ == "__main__":
     description = "Compare Nitsche's method for contact against a straight plane with PETSc SNES"
@@ -132,7 +133,7 @@ if __name__ == "__main__":
         indices = np.concatenate([top_facets, bottom_facets])
         values = np.hstack([top_values, bottom_values])
         sorted_facets = np.argsort(indices)
-        facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+        facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         mesh_data = (facet_marker, top_value, bottom_value)
 
         # Solve contact problem using Nitsche's method

--- a/python/demos/demo_nitsche_rigid_surface_cuas.py
+++ b/python/demos/demo_nitsche_rigid_surface_cuas.py
@@ -6,7 +6,7 @@ import argparse
 
 import numpy as np
 from dolfinx.io import XDMFFile
-from dolfinx.mesh import MeshTags, locate_entities_boundary
+from dolfinx.mesh import locate_entities_boundary, meshtags
 from mpi4py import MPI
 
 from dolfinx_contact.meshing import (convert_mesh, create_circle_circle_mesh,
@@ -126,7 +126,7 @@ if __name__ == "__main__":
             indices = np.concatenate([top_facets1, bottom_facets1, top_facets2, bottom_facets2])
             values = np.hstack([top_values, bottom_values, surface_values, sbottom_values])
             sorted_facets = np.argsort(indices)
-            facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+            facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         else:
             fname = "twomeshes"
             if simplex:
@@ -173,7 +173,7 @@ if __name__ == "__main__":
             indices = np.concatenate([top_facets1, bottom_facets1, top_facets2, bottom_facets2])
             values = np.hstack([top_values, bottom_values, surface_values, sbottom_values])
             sorted_facets = np.argsort(indices)
-            facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+            facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
 
     # Solver options
     newton_options = {"relaxation_parameter": 1.0}

--- a/python/demos/demo_nitsche_unbiased.py
+++ b/python/demos/demo_nitsche_unbiased.py
@@ -357,3 +357,7 @@ if __name__ == "__main__":
         u.name = "u"
         xdmf.write_function(u)
     list_timings(mesh.comm, [TimingType.wall])
+
+    import dolfinx.common
+    t = dolfinx.common.timing("Pack contact u")
+    print(t)

--- a/python/demos/demo_nitsche_unbiased.py
+++ b/python/demos/demo_nitsche_unbiased.py
@@ -7,6 +7,7 @@ import argparse
 import numpy as np
 from dolfinx.fem import Function, VectorFunctionSpace
 from dolfinx.io import XDMFFile
+from dolfinx.common import list_timings, TimingType
 from dolfinx.mesh import MeshTags, locate_entities_boundary
 from mpi4py import MPI
 
@@ -60,6 +61,8 @@ if __name__ == "__main__":
                         dest="refs", help="Number of mesh refinements")
     parser.add_argument("--load_steps", default=1, type=np.int32, dest="nload_steps",
                         help="Number of steps for gradual loading")
+    parser.add_argument("--res", default=0.1, type=np.float64, dest="res",
+                        help="Mesh resolution")
 
     # Parse input arguments or set to defualt values
     args = parser.parse_args()
@@ -119,7 +122,7 @@ if __name__ == "__main__":
         elif hex:
             fname = "hex"
             displacement = ([-1, 0, 0], [0, 0, 0])
-            create_hexahedral_mesh(fname)
+            create_hexahedral_mesh(fname, res=args.res)
             with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
                 mesh = xdmf.read_mesh(name="hex_d2")
             tdim = mesh.topology.dim
@@ -354,3 +357,4 @@ if __name__ == "__main__":
         xdmf.write_mesh(mesh)
         u.name = "u"
         xdmf.write_function(u)
+    list_timings(mesh.comm, [TimingType.wall])

--- a/python/demos/demo_nitsche_unbiased.py
+++ b/python/demos/demo_nitsche_unbiased.py
@@ -234,11 +234,10 @@ if __name__ == "__main__":
             facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         elif box:
             fname = "box_2D"
+            create_box_mesh_2D(filename=f"{fname}.msh", quads=not simplex, res=args.res)
             if simplex:
-                create_box_mesh_2D(filename=f"{fname}.msh")
                 convert_mesh(fname, f"{fname}.xdmf", "triangle", prune_z=True)
             else:
-                create_box_mesh_2D(filename=f"{fname}.msh", quads=True)
                 convert_mesh(fname, f"{fname}.xdmf", "quad", prune_z=True)
             convert_mesh(f"{fname}", f"{fname}_facets", "line", prune_z=True)
 

--- a/python/demos/demo_nitsche_unbiased.py
+++ b/python/demos/demo_nitsche_unbiased.py
@@ -5,19 +5,19 @@
 import argparse
 
 import numpy as np
+from dolfinx.common import TimingType, list_timings
 from dolfinx.fem import Function, VectorFunctionSpace
 from dolfinx.io import XDMFFile
-from dolfinx.common import list_timings, TimingType
-from dolfinx.mesh import MeshTags, locate_entities_boundary
+from dolfinx.mesh import locate_entities_boundary, meshtags
 from mpi4py import MPI
 
+from dolfinx_contact import update_geometry
 from dolfinx_contact.meshing import (convert_mesh, create_box_mesh_2D,
                                      create_box_mesh_3D,
                                      create_circle_circle_mesh,
                                      create_circle_plane_mesh,
-                                     create_sphere_plane_mesh,
-                                     create_hexahedral_mesh)
-from dolfinx_contact import update_geometry
+                                     create_hexahedral_mesh,
+                                     create_sphere_plane_mesh)
 from dolfinx_contact.unbiased.nitsche_unbiased import nitsche_unbiased
 
 if __name__ == "__main__":
@@ -117,7 +117,7 @@ if __name__ == "__main__":
             indices = np.concatenate([top_facets1, bottom_facets1, top_facets2, bottom_facets2])
             values = np.hstack([top_values, bottom_values, surface_values, sbottom_values])
             sorted_facets = np.argsort(indices)
-            facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+            facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
 
         elif hex:
             fname = "hex"
@@ -162,7 +162,7 @@ if __name__ == "__main__":
             indices = np.concatenate([top_facets1, bottom_facets1, top_facets2, bottom_facets2])
             values = np.hstack([top_values, bottom_values, surface_values, sbottom_values])
             sorted_facets = np.argsort(indices)
-            facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+            facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         else:
             fname = "sphere"
             create_sphere_plane_mesh(filename=f"{fname}.msh")
@@ -231,7 +231,7 @@ if __name__ == "__main__":
             indices = np.concatenate([top_facets1, bottom_facets1, top_facets2, bottom_facets2])
             values = np.hstack([top_values, bottom_values, surface_values, sbottom_values])
             sorted_facets = np.argsort(indices)
-            facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+            facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         elif box:
             fname = "box_2D"
             create_box_mesh_2D(filename=f"{fname}.msh", quads=not simplex, res=args.res)
@@ -304,7 +304,7 @@ if __name__ == "__main__":
             indices = np.concatenate([top_facets1, bottom_facets1, top_facets2, bottom_facets2])
             values = np.hstack([top_values, bottom_values, surface_values, sbottom_values])
             sorted_facets = np.argsort(indices)
-            facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+            facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
 
     # Solver options
     newton_options = {"relaxation_parameter": 1.0}

--- a/python/demos/gradual_loading.py
+++ b/python/demos/gradual_loading.py
@@ -3,13 +3,13 @@ import argparse
 import numpy as np
 from dolfinx.fem import Function, VectorFunctionSpace
 from dolfinx.io import XDMFFile
-from dolfinx.mesh import MeshTags, locate_entities_boundary
+from dolfinx.mesh import locate_entities_boundary, meshtags
 from mpi4py import MPI
 
+from dolfinx_contact import update_geometry
 from dolfinx_contact.meshing import (convert_mesh, create_circle_circle_mesh,
                                      create_circle_plane_mesh,
                                      create_sphere_plane_mesh)
-from dolfinx_contact import update_geometry
 from dolfinx_contact.one_sided.nitsche_rigid_surface_cuas import \
     nitsche_rigid_surface_cuas
 
@@ -119,7 +119,7 @@ if __name__ == "__main__":
             indices = np.concatenate([top_facets1, bottom_facets1, top_facets2, bottom_facets2])
             values = np.hstack([top_values, bottom_values, surface_values, sbottom_values])
             sorted_facets = np.argsort(indices)
-            facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+            facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         else:
             fname = "twomeshes"
             create_circle_plane_mesh(filename=f"{fname}.msh")
@@ -161,7 +161,7 @@ if __name__ == "__main__":
             indices = np.concatenate([top_facets1, bottom_facets1, top_facets2, bottom_facets2])
             values = np.hstack([top_values, bottom_values, surface_values, sbottom_values])
             sorted_facets = np.argsort(indices)
-            facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+            facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
 
     # Solver options
     newton_options = {"relaxation_parameter": 1.0}

--- a/python/demos/nitsche_euler_bernoulli.py
+++ b/python/demos/nitsche_euler_bernoulli.py
@@ -13,8 +13,8 @@ from dolfinx.fem.petsc import LinearProblem, NonlinearProblem
 from dolfinx.geometry import (BoundingBoxTree, compute_colliding_cells,
                               compute_collisions)
 from dolfinx.io import XDMFFile
-from dolfinx.mesh import (CellType, GhostMode, MeshTags, create_rectangle,
-                          locate_entities_boundary)
+from dolfinx.mesh import (CellType, GhostMode, create_rectangle,
+                          locate_entities_boundary, meshtags)
 from dolfinx.nls.petsc import NewtonSolver
 from mpi4py import MPI
 
@@ -50,7 +50,7 @@ def solve_euler_bernoulli(nx: int, ny: int, theta: float, gamma: float, linear_s
     values = np.hstack([left_values, top_values])
     # Sort values to work in parallel
     sorted = np.argsort(indices)
-    facet_marker = MeshTags(mesh, tdim - 1, indices[sorted], values[sorted])
+    facet_marker = meshtags(mesh, tdim - 1, indices[sorted], values[sorted])
 
     V = VectorFunctionSpace(mesh, ("CG", 1))
     h = 2 * ufl.Circumradius(mesh)

--- a/python/dolfinx_contact/meshing/contact_meshes.py
+++ b/python/dolfinx_contact/meshing/contact_meshes.py
@@ -140,7 +140,7 @@ def create_circle_circle_mesh(filename: str, quads: bool = False):
     gmsh.finalize()
 
 
-def create_box_mesh_2D(filename: str, quads: bool = False):
+def create_box_mesh_2D(filename: str, quads: bool = False, res=0.1):
     """
     Create two boxes, one slightly skewed
     """
@@ -151,6 +151,7 @@ def create_box_mesh_2D(filename: str, quads: bool = False):
 
     gmsh.initialize()
     if MPI.COMM_WORLD.rank == 0:
+        gmsh.option.setNumber("Mesh.CharacteristicLengthFactor", res)
 
         # Create box
         p0 = gmsh.model.occ.addPoint(-delta, 0, 0)

--- a/python/dolfinx_contact/meshing/hexahedral_meshes.py
+++ b/python/dolfinx_contact/meshing/hexahedral_meshes.py
@@ -25,7 +25,7 @@ def create_hexahedral_mesh(filename: str, order: int = 1, res=0.25):
         # Recombine tetrahedrons to hexahedrons
         gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 2)
         gmsh.option.setNumber("Mesh.RecombineAll", 2)
-        #gmsh.option.setNumber("Mesh.CharacteristicLengthFactor", 0.1)
+        # gmsh.option.setNumber("Mesh.CharacteristicLengthFactor", 0.1)
 
         circle = model.occ.addDisk(0, 0, 0, 2, 2)
         circle2 = model.occ.addDisk(3.5, 0, 0, 1, 1)

--- a/python/dolfinx_contact/meshing/hexahedral_meshes.py
+++ b/python/dolfinx_contact/meshing/hexahedral_meshes.py
@@ -14,7 +14,7 @@ from mpi4py import MPI
 __all__ = ["create_hexahedral_mesh"]
 
 
-def create_hexahedral_mesh(filename: str, order: int = 1):
+def create_hexahedral_mesh(filename: str, order: int = 1, res=0.25):
     if MPI.COMM_WORLD.rank == 0:
         gmsh.initialize()
         model = gmsh.model()
@@ -25,7 +25,7 @@ def create_hexahedral_mesh(filename: str, order: int = 1):
         # Recombine tetrahedrons to hexahedrons
         gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 2)
         gmsh.option.setNumber("Mesh.RecombineAll", 2)
-        gmsh.option.setNumber("Mesh.CharacteristicLengthFactor", 0.1)
+        #gmsh.option.setNumber("Mesh.CharacteristicLengthFactor", 0.1)
 
         circle = model.occ.addDisk(0, 0, 0, 2, 2)
         circle2 = model.occ.addDisk(3.5, 0, 0, 1, 1)
@@ -34,6 +34,18 @@ def create_hexahedral_mesh(filename: str, order: int = 1):
             fuse[0], 0, 0, 0.5, numElements=[5], recombine=True)
         model.occ.synchronize()
 
+        gmsh.model.mesh.field.add("Box", 1)
+        gmsh.model.mesh.field.setNumber(1, "VIn", res)
+        gmsh.model.mesh.field.setNumber(1, "VOut", 1.5 * res)
+        gmsh.model.mesh.field.setNumber(1, "XMin", -2)
+        gmsh.model.mesh.field.setNumber(1, "XMax", 2)
+        gmsh.model.mesh.field.setNumber(1, "YMin", -2)
+        gmsh.model.mesh.field.setNumber(1, "YMax", 2)
+        gmsh.model.mesh.field.setNumber(1, "ZMin", -2)
+        gmsh.model.mesh.field.setNumber(1, "ZMax", 2)
+
+        gmsh.model.mesh.field.setAsBackgroundMesh(1)
+        model.occ.synchronize()
         model.mesh.generate(3)
         model.mesh.setOrder(order)
         volume_entities = []

--- a/python/dolfinx_contact/one_sided/nitsche_cuas.py
+++ b/python/dolfinx_contact/one_sided/nitsche_cuas.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier:    MIT
 
-from typing import Tuple, Dict
+from typing import Dict, Tuple
 
 import basix
 import dolfinx_cuas
@@ -23,7 +23,7 @@ from dolfinx_contact.helpers import (epsilon, lame_parameters,
 __all__ = ["nitsche_cuas"]
 
 
-def nitsche_cuas(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.MeshTags, int, int],
+def nitsche_cuas(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.meshtags, int, int],
                  physical_parameters: dict = {}, nitsche_parameters: Dict[str, float] = {},
                  plane_loc: float = 0.0, vertical_displacement: float = -0.1,
                  nitsche_bc: bool = True, quadrature_degree: int = 5, form_compiler_params: Dict = {},

--- a/python/dolfinx_contact/one_sided/nitsche_rigid_surface.py
+++ b/python/dolfinx_contact/one_sided/nitsche_rigid_surface.py
@@ -20,7 +20,7 @@ from dolfinx_contact.helpers import (R_minus, epsilon, lame_parameters,
                                      rigid_motions_nullspace, sigma_func)
 
 
-def nitsche_rigid_surface(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int, int, int, int],
+def nitsche_rigid_surface(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTagsMetaClass, int, int, int, int],
                           physical_parameters: dict = {}, nitsche_parameters: Dict[str, float] = {},
                           vertical_displacement: float = -0.1, nitsche_bc: bool = False, quadrature_degree: int = 5,
                           form_compiler_params: Dict = {}, jit_params: Dict = {}, petsc_options: Dict = {},

--- a/python/dolfinx_contact/one_sided/nitsche_rigid_surface_cuas.py
+++ b/python/dolfinx_contact/one_sided/nitsche_rigid_surface_cuas.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier:    MIT
 
-from typing import Tuple, Dict
+from typing import Dict, Tuple
 
 import basix
 import dolfinx.common as _common
@@ -24,7 +24,7 @@ __all__ = ["nitsche_rigid_surface_cuas"]
 kt = dolfinx_contact.cpp.Kernel
 
 
-def nitsche_rigid_surface_cuas(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int, int, int, int],
+def nitsche_rigid_surface_cuas(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTagsMetaClass, int, int, int, int],
                                physical_parameters: dict = {}, nitsche_parameters: Dict[str, float] = {},
                                vertical_displacement: float = -0.1, nitsche_bc: bool = True, quadrature_degree: int = 5,
                                form_compiler_params: Dict = {}, jit_params: Dict = {}, petsc_options: Dict = {},

--- a/python/dolfinx_contact/one_sided/nitsche_ufl.py
+++ b/python/dolfinx_contact/one_sided/nitsche_ufl.py
@@ -19,7 +19,7 @@ from dolfinx_contact.helpers import (R_minus, epsilon, lame_parameters,
 __all__ = ["nitsche_ufl"]
 
 
-def nitsche_ufl(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.MeshTags, int, int],
+def nitsche_ufl(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.MeshTagsMetaClass, int, int],
                 physical_parameters: dict = {}, nitsche_parameters: Dict[str, float] = {},
                 plane_loc: float = 0.0, vertical_displacement: float = -0.1,
                 nitsche_bc: bool = True, quadrature_degree: int = 5, form_compiler_params: Dict = {},

--- a/python/dolfinx_contact/one_sided/snes_against_plane.py
+++ b/python/dolfinx_contact/one_sided/snes_against_plane.py
@@ -17,7 +17,7 @@ from dolfinx_contact.helpers import (NonlinearPDE_SNESProblem, epsilon,
                                      sigma_func)
 
 
-def snes_solver(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.MeshTags, int, int],
+def snes_solver(mesh: dmesh.Mesh, mesh_data: Tuple[dmesh.MeshTagsMetaClass, int, int],
                 physical_parameters: dict = {}, plane_loc: float = 0.0, vertical_displacement: float = -0.1,
                 quadrature_degree: int = 5, form_compiler_params: Dict = {},
                 jit_params: Dict = {}, petsc_options: Dict = {}, snes_options: Dict = {}) -> _fem.Function:

--- a/python/dolfinx_contact/unbiased/nitsche_unbiased.py
+++ b/python/dolfinx_contact/unbiased/nitsche_unbiased.py
@@ -138,44 +138,51 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int, int
     # Custom assembly
     _log.set_log_level(_log.LogLevel.OFF)
     # create contact class
-    contact = dolfinx_contact.cpp.Contact(facet_marker, [surface_value_0, surface_value_1], V._cpp_object)
+    with _common.Timer("~Contact: Init"):
+        contact = dolfinx_contact.cpp.Contact(facet_marker, [surface_value_0, surface_value_1], V._cpp_object)
     contact.set_quadrature_degree(quadrature_degree)
-    contact.create_distance_map(0, 1)
-    contact.create_distance_map(1, 0)
+    with _common.Timer("~Contact: Distance maps"):
+        contact.create_distance_map(0, 1)
+        contact.create_distance_map(1, 0)
     # pack constants
     consts = np.array([gamma, theta])
 
     # Pack material parameters mu and lambda on each contact surface
-    V2 = _fem.FunctionSpace(mesh, ("DG", 0))
-    lmbda2 = _fem.Function(V2)
-    lmbda2.interpolate(lambda x: np.full((1, x.shape[1]), lmbda))
-    mu2 = _fem.Function(V2)
-    mu2.interpolate(lambda x: np.full((1, x.shape[1]), mu))
-    facets_0 = facet_marker.indices[facet_marker.values == surface_value_0]
-    facets_1 = facet_marker.indices[facet_marker.values == surface_value_1]
+    with _common.Timer("~Contact: Interpolate coeffs (mu, lmbda)"):
+        V2 = _fem.FunctionSpace(mesh, ("DG", 0))
+        lmbda2 = _fem.Function(V2)
+        lmbda2.interpolate(lambda x: np.full((1, x.shape[1]), lmbda))
+        mu2 = _fem.Function(V2)
+        mu2.interpolate(lambda x: np.full((1, x.shape[1]), mu))
 
-    integral = _fem.IntegralType.exterior_facet
-    entities_0 = dolfinx_cuas.compute_active_entities(mesh, facets_0, integral)
-    material_0 = dolfinx_cuas.pack_coefficients([mu2, lmbda2], entities_0)
+    with _common.Timer("~Contact: Compute active entities"):
+        facets_0 = facet_marker.indices[facet_marker.values == surface_value_0]
+        facets_1 = facet_marker.indices[facet_marker.values == surface_value_1]
+        integral = _fem.IntegralType.exterior_facet
+        entities_0 = dolfinx_cuas.compute_active_entities(mesh, facets_0, integral)
+        entities_1 = dolfinx_cuas.compute_active_entities(mesh, facets_1, integral)
 
-    entities_1 = dolfinx_cuas.compute_active_entities(mesh, facets_1, integral)
-    material_1 = dolfinx_cuas.pack_coefficients([mu2, lmbda2], entities_1)
+    with _common.Timer("~Contact: Pack coeffs (mu, lmbda"):
+        material_0 = dolfinx_cuas.pack_coefficients([mu2, lmbda2], entities_0)
+        material_1 = dolfinx_cuas.pack_coefficients([mu2, lmbda2], entities_1)
 
     # Pack celldiameter on each surface
-    surface_cells = np.unique(np.hstack([entities_0[:, 0], entities_1[:, 0]]))
-    h_int = _fem.Function(V2)
-    expr = _fem.Expression(h, V2.element.interpolation_points)
-    h_int.interpolate(expr, surface_cells)
-    h_0 = dolfinx_cuas.pack_coefficients([h_int], entities_0)
-    h_1 = dolfinx_cuas.pack_coefficients([h_int], entities_1)
+    with _common.Timer("~Contact: Compute and pack celldiameter"):
+        surface_cells = np.unique(np.hstack([entities_0[:, 0], entities_1[:, 0]]))
+        h_int = _fem.Function(V2)
+        expr = _fem.Expression(h, V2.element.interpolation_points)
+        h_int.interpolate(expr, surface_cells)
+        h_0 = dolfinx_cuas.pack_coefficients([h_int], entities_0)
+        h_1 = dolfinx_cuas.pack_coefficients([h_int], entities_1)
 
     # Pack gap, normals and test functions on each surface
-    gap_0 = contact.pack_gap(0)
-    n_0 = contact.pack_ny(0, gap_0)
-    test_fn_0 = contact.pack_test_functions(0, gap_0)
-    gap_1 = contact.pack_gap(1)
-    n_1 = contact.pack_ny(1, gap_1)
-    test_fn_1 = contact.pack_test_functions(1, gap_1)
+    with _common.Timer("~Contact: Pack gap, normals, testfunction"):
+        gap_0 = contact.pack_gap(0)
+        n_0 = contact.pack_ny(0, gap_0)
+        test_fn_0 = contact.pack_test_functions(0, gap_0)
+        gap_1 = contact.pack_gap(1)
+        n_1 = contact.pack_ny(1, gap_1)
+        test_fn_1 = contact.pack_test_functions(1, gap_1)
 
     # Concatenate all coeffs
     coeff_0 = np.hstack([material_0, h_0, gap_0, n_0, test_fn_0])
@@ -183,41 +190,54 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int, int
 
     # Assemble jacobian
     J_cuas = _fem.form(J)
-    kernel_jac = contact.generate_kernel(kt.Jac)
+    with _common.Timer("~Contact: Generate kernel"):
+        kernel_jac = contact.generate_kernel(kt.Jac)
 
+    @_common.timed("~Contact: Create matrix")
     def create_A():
         return contact.create_matrix(J_cuas)
 
+    @_common.timed("~Contact: Assemble matrix")
     def A(x, A):
         u.vector[:] = x.array
-        u_opp_0 = contact.pack_u_contact(0, u._cpp_object, gap_0)
-        u_opp_1 = contact.pack_u_contact(1, u._cpp_object, gap_1)
-        u_0 = dolfinx_cuas.pack_coefficients([u], entities_0)
-        u_1 = dolfinx_cuas.pack_coefficients([u], entities_1)
+        with _common.Timer("~~Contact: Pack u contact (in assemble matrix"):
+            u_opp_0 = contact.pack_u_contact(0, u._cpp_object, gap_0)
+            u_opp_1 = contact.pack_u_contact(1, u._cpp_object, gap_1)
+        with _common.Timer("~~Contact: Pack u (in assemble matrix"):
+            u_0 = dolfinx_cuas.pack_coefficients([u], entities_0)
+            u_1 = dolfinx_cuas.pack_coefficients([u], entities_1)
         c_0 = np.hstack([coeff_0, u_0, u_opp_0])
         c_1 = np.hstack([coeff_1, u_1, u_opp_1])
-        contact.assemble_matrix(A, [], 0, kernel_jac, c_0, consts)
-        contact.assemble_matrix(A, [], 1, kernel_jac, c_1, consts)
-        _fem.petsc.assemble_matrix(A, J_cuas)
+        with _common.Timer("~~Contact: Contract contributions (in assemble matrix"):
+            contact.assemble_matrix(A, [], 0, kernel_jac, c_0, consts)
+            contact.assemble_matrix(A, [], 1, kernel_jac, c_1, consts)
+        with _common.Timer("~~Contact: Standard contributions (in assemble matrix"):
+            _fem.petsc.assemble_matrix(A, J_cuas)
 
     # assemble rhs
     F_cuas = _fem.form(F)
     kernel_rhs = contact.generate_kernel(kt.Rhs)
 
+    @_common.timed("~Contact: Create vector")
     def create_b():
         return _fem.petsc.create_vector(F_cuas)
 
+    @_common.timed("~Contact: Assemble residual")
     def F(x, b):
         u.vector[:] = x.array
-        u_opp_0 = contact.pack_u_contact(0, u._cpp_object, gap_0)
-        u_opp_1 = contact.pack_u_contact(1, u._cpp_object, gap_1)
-        u_0 = dolfinx_cuas.pack_coefficients([u], entities_0)
-        u_1 = dolfinx_cuas.pack_coefficients([u], entities_1)
+        with _common.Timer("~~Contact: Pack u contact (in assemble vector"):
+            u_opp_0 = contact.pack_u_contact(0, u._cpp_object, gap_0)
+            u_opp_1 = contact.pack_u_contact(1, u._cpp_object, gap_1)
+        with _common.Timer("~~Contact: Pack u (in assemble vector"):
+            u_0 = dolfinx_cuas.pack_coefficients([u], entities_0)
+            u_1 = dolfinx_cuas.pack_coefficients([u], entities_1)
         c_0 = np.hstack([coeff_0, u_0, u_opp_0])
         c_1 = np.hstack([coeff_1, u_1, u_opp_1])
-        contact.assemble_vector(b, 0, kernel_rhs, c_0, consts)
-        contact.assemble_vector(b, 1, kernel_rhs, c_1, consts)
-        _fem.petsc.assemble_vector(b, F_cuas)
+        with _common.Timer("~~Contact: Contact contributions (in assemble vector"):
+            contact.assemble_vector(b, 0, kernel_rhs, c_0, consts)
+            contact.assemble_vector(b, 1, kernel_rhs, c_1, consts)
+        with _common.Timer("~~Contact: Standard contributions (in assemble vector"):
+            _fem.petsc.assemble_vector(b, F_cuas)
 
     # Setup non-linear problem and Newton-solver
     problem = dolfinx_cuas.NonlinearProblemCUAS(F, A, create_b, create_A)
@@ -258,7 +278,7 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int, int
     _log.set_log_level(_log.LogLevel.INFO)
 
     # Solve non-linear problem
-    with _common.Timer(f"{dofs_global} Solve Nitsche"):
+    with _common.Timer(f"~Contact: {dofs_global} Solve Nitsche"):
         n, converged = solver.solve(u)
     u.x.scatter_forward()
 

--- a/python/dolfinx_contact/unbiased/nitsche_unbiased.py
+++ b/python/dolfinx_contact/unbiased/nitsche_unbiased.py
@@ -22,7 +22,7 @@ kt = dolfinx_contact.cpp.Kernel
 __all__ = ["nitsche_unbiased"]
 
 
-def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTags, int, int, int, int],
+def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTagsMetaClass, int, int, int, int],
                      physical_parameters: dict = {}, nitsche_parameters: Dict[str, float] = {},
                      displacement: Tuple[list[float], list[float]] = [[0, 0, 0], [0, 0, 0]],
                      nitsche_bc: bool = True, quadrature_degree: int = 5,

--- a/python/tests/test_contact_kernels.py
+++ b/python/tests/test_contact_kernels.py
@@ -13,7 +13,7 @@ from dolfinx.fem import (Function, FunctionSpace, IntegralType,
                          VectorFunctionSpace, form)
 from dolfinx.fem.petsc import (assemble_matrix, assemble_vector, create_matrix,
                                create_vector)
-from dolfinx.mesh import (MeshTags, create_unit_cube, create_unit_square,
+from dolfinx.mesh import (meshtags, create_unit_cube, create_unit_square,
                           locate_entities_boundary)
 from mpi4py import MPI
 
@@ -44,7 +44,7 @@ def test_vector_surface_kernel(dim, kernel_type, P, Q):
                                                               np.isclose(x[0], 1.0)))
     facets = np.sort(facets)
     values = np.ones(len(facets), dtype=np.int32)
-    ft = MeshTags(mesh, mesh.topology.dim - 1, facets, values)
+    ft = meshtags(mesh, mesh.topology.dim - 1, facets, values)
 
     # Define variational form
     V = VectorFunctionSpace(mesh, ("CG", P))
@@ -163,7 +163,7 @@ def test_matrix_surface_kernel(dim, kernel_type, P, Q):
                                                                            np.isclose(x[0], 1.0)))
     facets = np.sort(facets)
     values = np.ones(len(facets), dtype=np.int32)
-    ft = MeshTags(mesh, mesh.topology.dim - 1, facets, values)
+    ft = meshtags(mesh, mesh.topology.dim - 1, facets, values)
 
     # Define variational form
     V = VectorFunctionSpace(mesh, ("CG", P))

--- a/python/tests/test_dolfinx_cuas.py
+++ b/python/tests/test_dolfinx_cuas.py
@@ -88,7 +88,7 @@ def test_contact_kernel(theta, gamma, dim, gap):
         indices = np.concatenate([top_facets, bottom_facets])
         values = np.hstack([top_values, bottom_values])
         sorted_facets = np.argsort(indices)
-        facet_marker = dolfinx.mesh.MeshTags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
+        facet_marker = dolfinx.mesh.meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         bottom_facets = np.sort(bottom_facets)
 
         V = dolfinx.fem.VectorFunctionSpace(mesh, ("CG", 1))

--- a/python/tests/test_nitsche_bc_plane_stress_beam.py
+++ b/python/tests/test_nitsche_bc_plane_stress_beam.py
@@ -10,8 +10,8 @@ import ufl
 from dolfinx.fem import Function, VectorFunctionSpace, assemble_scalar, form
 from dolfinx.fem.petsc import LinearProblem, NonlinearProblem
 from dolfinx.io import XDMFFile
-from dolfinx.mesh import (CellType, GhostMode, MeshTags, create_rectangle,
-                          locate_entities_boundary)
+from dolfinx.mesh import (CellType, GhostMode, create_rectangle,
+                          locate_entities_boundary, meshtags)
 from dolfinx.nls.petsc import NewtonSolver
 from mpi4py import MPI
 
@@ -42,7 +42,7 @@ def solve_manufactured(nx: int, ny: int, theta: float, gamma: float,
 
     # Sort values to work in parallel
     sorted = np.argsort(left_facets)
-    facet_marker = MeshTags(mesh, tdim - 1, left_facets[sorted], left_values[sorted])
+    facet_marker = meshtags(mesh, tdim - 1, left_facets[sorted], left_values[sorted])
 
     V = VectorFunctionSpace(mesh, ("CG", 1))
     n = ufl.FacetNormal(mesh)

--- a/python/tests/test_pack_u.py
+++ b/python/tests/test_pack_u.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2021 Jørgen S. Dokken
+#
+# SPDX-License-Identifier:    MIT
+
+
+import numpy as np
+import pytest
+import ufl
+from dolfinx import fem, graph
+from dolfinx import mesh as msh
+from mpi4py import MPI
+
+import dolfinx_contact
+
+
+@pytest.mark.skipif(MPI.COMM_WORLD.size > 1,
+                    reason="This test should only be run in serial.")
+def test_pack_u():
+    """
+    Test that evaluation of a function u on the opposite surface is correct
+
+    """
+    # Create mesh consisting of 4 triangles, where they are grouped in two
+    # disconnected regions (with two cells in each region)
+    points = np.array([[0, -1], [0.5, -1], [0, -2], [1, -1],
+                       [0, 1], [0.3, 1], [2, 2], [1, 1]], dtype=np.float64)
+    cells = np.array([[0, 1, 2], [4, 5, 6], [1, 3, 2], [5, 6, 7]], dtype=np.int64)
+
+    cell_type = msh.CellType.triangle
+    domain = ufl.Mesh(ufl.VectorElement("Lagrange", ufl.Cell(cell_type.name), 1))
+    cells = graph.create_adjacencylist(cells)
+    mesh = msh.create_mesh(MPI.COMM_WORLD, cells, points, domain, msh.GhostMode.none)
+
+    def f(x):
+        vals = np.zeros((2, x.shape[1]))
+        vals[0] = 0.1 * x[0]
+        vals[1] = 0.23 * x[1]
+        return vals
+
+    # Compute function that is known on each side
+    V = fem.VectorFunctionSpace(mesh, ("CG", 1))
+    u = fem.Function(V)
+    u.interpolate(f)
+
+    # Mark two facets on each side of gap
+    mesh.topology.create_connectivity(2, 1)
+    s0 = msh.locate_entities_boundary(mesh, 1, lambda x: np.isclose(x[1], 1))
+    v0 = np.full(len(s0), 1, dtype=np.int32)
+    s1 = msh.locate_entities_boundary(mesh, 1, lambda x: np.isclose(x[1], -1))
+    v1 = np.full(len(s1), 2, dtype=np.int32)
+    ss = [s0, s1]
+
+    facets = np.hstack([s0, s1])
+    values = np.hstack([v0, v1])
+    arg_sort = np.argsort(facets)
+    facet_marker = msh.MeshTags(mesh, 1, facets[arg_sort], values[arg_sort])
+
+    # Compute contact class
+    quadrature_degree = 2
+    contact = dolfinx_contact.cpp.Contact(facet_marker, [1, 2], V._cpp_object)
+    contact.set_quadrature_degree(quadrature_degree)
+    contact.create_distance_map(0, 1)
+    contact.create_distance_map(1, 0)
+
+    for i in range(2):
+        gap = contact.pack_gap(i)
+        u_opposite = contact.pack_u_contact(i, u._cpp_object, gap)
+
+        gap_reshape = gap.reshape(len(ss[i]), -2, 2)
+
+        q_points = np.zeros_like(gap_reshape)
+        for j in range(len(s0)):
+            q_points[j] = contact.qp_phys(i, j)
+        new_points = q_points + gap_reshape
+
+        for j in range(len(s0)):
+            f_exact = f(new_points[j].T).T.reshape(-1)
+            assert(np.allclose(f_exact, u_opposite[j]))

--- a/python/tests/test_pack_u.py
+++ b/python/tests/test_pack_u.py
@@ -53,7 +53,7 @@ def test_pack_u():
     facets = np.hstack([s0, s1])
     values = np.hstack([v0, v1])
     arg_sort = np.argsort(facets)
-    facet_marker = msh.MeshTags(mesh, 1, facets[arg_sort], values[arg_sort])
+    facet_marker = msh.meshtags(mesh, 1, facets[arg_sort], values[arg_sort])
 
     # Compute contact class
     quadrature_degree = 2

--- a/python/tests/test_projection.py
+++ b/python/tests/test_projection.py
@@ -11,7 +11,7 @@ import dolfinx.fem as _fem
 import numpy as np
 import pytest
 from dolfinx.io import XDMFFile
-from dolfinx.mesh import MeshTags, locate_entities_boundary
+from dolfinx.mesh import meshtags, locate_entities_boundary
 from mpi4py import MPI
 
 import dolfinx_contact
@@ -68,7 +68,7 @@ def test_projection(q_deg, surf, dim):
     indices = np.concatenate([facets_0, facets_1])
     values = np.hstack([values_0, values_1])
     sorted_ind = np.argsort(indices)
-    facet_marker = MeshTags(mesh, tdim - 1, indices[sorted_ind], values[sorted_ind])
+    facet_marker = meshtags(mesh, tdim - 1, indices[sorted_ind], values[sorted_ind])
 
     # Functions space
     V = _fem.VectorFunctionSpace(mesh, ("CG", 1))


### PR DESCRIPTION
Runtimes of pack operation in various demos:
(num_calls, total_wall_time, total_user_time,  total_system_time)
```python
python3 demo_nitsche_unbiased.py
PR: (42, 0.13808027400000003, 0.18000000000000002, 0.0)
Main: (42, 0.173836164, 0.16, 0.0)


python3 demo_nitsche_unbiased.py --curved --load_steps=10
PR: (324, 1.0152243200000004, 1.0500000000000007, 0.0)
Main: (324, 1.2286705770000013, 1.2000000000000008, 0.0)


python3 demo_nitsche_unbiased.py --curved --load_steps=10 --simplex
PR: (268, 0.049542706999999984, 0.04, 0.0)
Main: (268, 0.14214139500000006, 0.18000000000000002, 0.0)

python3 demo_nitsche_unbiased.py --curved --load_steps=10 --simplex --3D
PR: (280, 1.1780993110000004, 1.1300000000000008, 0.02)
Main: (280, 4.273338933999999, 4.259999999999984, 0.01)

python3 demo_nitsche_unbiased.py --curved --load_steps=10 --3D --hex
PR: (280, 26.983777086, 26.970000000000088, 0.060000000000000005)
Main: (280, 30.190133080000017, 30.210000000000015, 0.0)
```