### PR TITLE
Sarah/adapt newton

### DIFF
--- a/cpp/Contact.cpp
+++ b/cpp/Contact.cpp
@@ -75,6 +75,26 @@ dolfinx_contact::Contact::Contact(
   }
 }
 //------------------------------------------------------------------------------------------------
+std::size_t dolfinx_contact::Contact::coefficients_size()
+{
+  // mesh data
+  auto mesh = _marker->mesh();
+  const std::size_t gdim = mesh->geometry().dim(); // geometrical dimension
+
+  // Extract function space data (assuming same test and trial space)
+  std::shared_ptr<const dolfinx::fem::DofMap> dofmap = _V->dofmap();
+  const std::size_t ndofs_cell = dofmap->cell_dofs(0).size();
+  const std::size_t bs = dofmap->bs();
+
+  // NOTE: Assuming same number of quadrature points on each cell
+  const std::size_t num_q_points = _qp_ref_facet[0].shape(0);
+  const std::size_t max_links
+      = *std::max_element(_max_links.begin(), _max_links.end());
+
+  return 3 + num_q_points * (2 * gdim + ndofs_cell * bs * max_links + bs)
+         + ndofs_cell * bs;
+}
+
 Mat dolfinx_contact::Contact::create_petsc_matrix(
     const dolfinx::fem::Form<PetscScalar>& a, const std::string& type)
 {

--- a/cpp/Contact.h
+++ b/cpp/Contact.h
@@ -63,6 +63,9 @@ public:
   int quadrature_degree() const { return _quadrature_degree; }
   void set_quadrature_degree(int deg) { _quadrature_degree = deg; }
 
+  // return size of coefficients vector per facet on s
+  std::size_t coefficients_size();
+
   /// return distance map (adjacency map mapping quadrature points on surface
   /// to closest facet on other surface)
   /// @param[in] surface - index of the surface

--- a/python/dolfinx_contact/newton_solver.py
+++ b/python/dolfinx_contact/newton_solver.py
@@ -97,7 +97,7 @@ class NewtonSolver():
         """Get the residual vector"""
         return self._b
 
-    def setJ(self, J: Callable[[PETSc.Vec, PETSc.Mat], None]):
+    def setJ(self, J: Callable[[PETSc.Vec, PETSc.Mat, list[numpy.ndarray]], None]):
         """
         Set the function for computing the Jacobian
         Args:
@@ -105,7 +105,7 @@ class NewtonSolver():
         """
         self._compute_jacobian = J
 
-    def setF(self, F: Callable[[PETSc.Vec, PETSc.Vec], None]):
+    def setF(self, F: Callable[[PETSc.Vec, PETSc.Vec, list[numpy.ndarray]], None]):
         """
         Set the function for computing the residual
         Args:
@@ -113,7 +113,7 @@ class NewtonSolver():
         """
         self._compute_residual = F
 
-    def setP(self, P: Callable[[PETSc.Vec, PETSc.Mat], None], Pmat: PETSc.Mat):
+    def setP(self, P: Callable[[PETSc.Vec, PETSc.Mat, list[numpy.ndarray]], None], Pmat: PETSc.Mat):
         """
         Set the function for computing the preconditioner matrix
         Args:
@@ -123,7 +123,7 @@ class NewtonSolver():
         self._compute_preconditioner = P
         self._P = Pmat
 
-    def setCoeffs(self, Coeffs: Callable[[PETSc.Vec, Sequence[list[float]]], None]):
+    def setCoeffs(self, Coeffs: Callable[[PETSc.Vec, list[numpy.ndarray]], None]):
         """
         Set the function for computing the coefficients needed for assembly
         Args:

--- a/python/dolfinx_contact/unbiased/nitsche_unbiased.py
+++ b/python/dolfinx_contact/unbiased/nitsche_unbiased.py
@@ -215,39 +215,36 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTagsMetaClass,
     with _common.Timer("~Contact: Create vector"):
         b = _fem.petsc.create_vector(F_cuas)
 
-    @_common.timed("~Contact: Assemble residual")
-    def compute_residual(x, b):
-        b.zeroEntries()
+    @_common.timed("~Contact: Update coefficients")
+    def compute_coefficients(x):
         u.vector[:] = x.array
-        with _common.Timer("~~Contact: Pack u contact (in assemble vector)"):
+        with _common.Timer("~~Contact: Pack u contact"):
             u_opp_0 = contact.pack_u_contact(0, u._cpp_object, gap_0)
             u_opp_1 = contact.pack_u_contact(1, u._cpp_object, gap_1)
-        with _common.Timer("~~Contact: Pack u (in assemble vector)"):
+        with _common.Timer("~~Contact: Pack u"):
             u_0 = dolfinx_cuas.pack_coefficients([u], entities_0)
             u_1 = dolfinx_cuas.pack_coefficients([u], entities_1)
         c_0 = np.hstack([coeff_0, u_0, u_opp_0])
         c_1 = np.hstack([coeff_1, u_1, u_opp_1])
+        return [c_0, c_1]
+
+    @_common.timed("~Contact: Assemble residual")
+    def compute_residual(x, b, coeffs):
+        b.zeroEntries()
+        u.vector[:] = x.array
         with _common.Timer("~~Contact: Contact contributions (in assemble vector)"):
-            contact.assemble_vector(b, 0, kernel_rhs, c_0, consts)
-            contact.assemble_vector(b, 1, kernel_rhs, c_1, consts)
+            contact.assemble_vector(b, 0, kernel_rhs, coeffs[0], consts)
+            contact.assemble_vector(b, 1, kernel_rhs, coeffs[1], consts)
         with _common.Timer("~~Contact: Standard contributions (in assemble vector)"):
             _fem.petsc.assemble_vector(b, F_cuas)
 
     @_common.timed("~Contact: Assemble matrix")
-    def compute_jacobian_matrix(x, A):
+    def compute_jacobian_matrix(x, A, coeffs):
         u.vector[:] = x.array
         A.zeroEntries()
-        with _common.Timer("~~Contact: Pack u contact (in assemble matrix)"):
-            u_opp_0 = contact.pack_u_contact(0, u._cpp_object, gap_0)
-            u_opp_1 = contact.pack_u_contact(1, u._cpp_object, gap_1)
-        with _common.Timer("~~Contact: Pack u (in assemble matrix)"):
-            u_0 = dolfinx_cuas.pack_coefficients([u], entities_0)
-            u_1 = dolfinx_cuas.pack_coefficients([u], entities_1)
-        c_0 = np.hstack([coeff_0, u_0, u_opp_0])
-        c_1 = np.hstack([coeff_1, u_1, u_opp_1])
         with _common.Timer("~~Contact: Contact contributions (in assemble matrix)"):
-            contact.assemble_matrix(A, [], 0, kernel_jac, c_0, consts)
-            contact.assemble_matrix(A, [], 1, kernel_jac, c_1, consts)
+            contact.assemble_matrix(A, [], 0, kernel_jac, coeffs[0], consts)
+            contact.assemble_matrix(A, [], 1, kernel_jac, coeffs[1], consts)
         with _common.Timer("~~Contact: Standard contributions (in assemble matrix)"):
             _fem.petsc.assemble_matrix(A, J_cuas)
         A.assemble()
@@ -257,6 +254,7 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_data: Tuple[_mesh.MeshTagsMetaClass,
     # Set matrix-vector computations
     newton_solver.setF(compute_residual)
     newton_solver.setJ(compute_jacobian_matrix)
+    newton_solver.setCoeffs(compute_coefficients)
 
     # Set rigid motion nullspace
     null_space = rigid_motions_nullspace(V)

--- a/python/dolfinx_contact/wrappers.cpp
+++ b/python/dolfinx_contact/wrappers.cpp
@@ -111,6 +111,7 @@ PYBIND11_MODULE(cpp, m)
                  dolfinx::graph::AdjacencyList<std::int32_t>>(
                  std::move(data), std::move(offsets));
            })
+      .def("coefficients_size", &dolfinx_contact::Contact::coefficients_size)
       .def("set_quadrature_degree",
            &dolfinx_contact::Contact::set_quadrature_degree)
       .def("generate_kernel",


### PR DESCRIPTION
Add compute_coefficients to Newton solver so that the coefficients can be used both for computing the residual and the jacobian.
Reduces calls to packing functions.