### PR TITLE
Fix submesh

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,11 +1,11 @@
 name: Run sonarcloud analysis
 on:
   push:
-    branches-ignore:
-     - '**'
-    # branches:
-    #   - main
-    #   - dokken/*
+    # branches-ignore:
+    #   - "**"
+    branches:
+      - main
+      - dokken/*
   # pull_request:
   #   branches:
   #     - main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,11 +1,11 @@
 name: Run sonarcloud analysis
 on:
   push:
-    # branches-ignore:
-    #   - "**"
-    branches:
-      - main
-      - dokken/*
+    branches-ignore:
+      - "**"
+    # branches:
+    #   - main
+    #   - dokken/*
   # pull_request:
   #   branches:
   #     - main

--- a/cpp/Contact.cpp
+++ b/cpp/Contact.cpp
@@ -153,15 +153,16 @@ void dolfinx_contact::Contact::assemble_matrix(
     const xtl::span<const PetscScalar>& constants)
 {
   auto mesh = _marker->mesh();
-  const int gdim = mesh->geometry().dim(); // geometrical dimension
+  assert(mesh);
 
-  // Prepare cell geometry
+  // Extract geometry data
+  const dolfinx::mesh::Geometry& geometry = mesh->geometry();
+  const int gdim = geometry.dim();
   const dolfinx::graph::AdjacencyList<std::int32_t>& x_dofmap
-      = mesh->geometry().dofmap();
-
-  // FIXME: Add proper interface for num coordinate dofs
-  const std::size_t num_dofs_g = x_dofmap.num_links(0);
-  xtl::span<const double> x_g = mesh->geometry().x();
+      = geometry.dofmap();
+  xtl::span<const double> x_g = geometry.x();
+  const dolfinx::fem::CoordinateElement& cmap = geometry.cmap();
+  const std::size_t num_dofs_g = cmap.dim();
 
   // Extract function space data (assuming same test and trial space)
   std::shared_ptr<const dolfinx::fem::DofMap> dofmap = _V->dofmap();
@@ -235,15 +236,17 @@ void dolfinx_contact::Contact::assemble_vector(
 {
   // Extract mesh
   auto mesh = _marker->mesh();
-  const int gdim = mesh->geometry().dim(); // geometrical dimension
+  assert(mesh);
+  const dolfinx::mesh::Geometry& geometry = mesh->geometry();
+  const int gdim = geometry.dim(); // geometrical dimension
 
   // Prepare cell geometry
   const dolfinx::graph::AdjacencyList<std::int32_t>& x_dofmap
-      = mesh->geometry().dofmap();
+      = geometry.dofmap();
+  xtl::span<const double> x_g = geometry.x();
 
-  // FIXME: Add proper interface for num coordinate dofs
-  const std::size_t num_dofs_g = x_dofmap.num_links(0);
-  xtl::span<const double> x_g = mesh->geometry().x();
+  const dolfinx::fem::CoordinateElement& cmap = geometry.cmap();
+  const std::size_t num_dofs_g = cmap.dim();
 
   // Extract function space data (assuming same test and trial space)
   std::shared_ptr<const dolfinx::fem::DofMap> dofmap = _V->dofmap();

--- a/cpp/SubMesh.cpp
+++ b/cpp/SubMesh.cpp
@@ -22,20 +22,22 @@ dolfinx_contact::SubMesh::SubMesh(
               cells.end()); // remove duplicates
 
   // save sorted cell vector as _parent_cells
-  _parent_cells = cells;
 
   // call doflinx::mesh::create_submesh and save ouput to member variables
-  auto [submesh, vertex_map, x_dof_map] = dolfinx::mesh::create_submesh(
-      *mesh, tdim, xtl::span(cells.data(), cells.size()));
+  auto [submesh, cell_map, vertex_map, x_dof_map]
+      = dolfinx::mesh::create_submesh(*mesh, tdim,
+                                      xtl::span(cells.data(), cells.size()));
+  _parent_cells = cell_map;
+
   _mesh = std::make_shared<dolfinx::mesh::Mesh>(submesh);
   _submesh_to_mesh_vertex_map = vertex_map;
   _submesh_to_mesh_x_dof_map = x_dof_map;
 
   // create/retrieve connectivities on submesh
-  _mesh->topology().create_connectivity(tdim - 1, tdim);
+  _mesh->topology_mutable().create_connectivity(tdim - 1, tdim);
   auto f_to_c = _mesh->topology().connectivity(tdim - 1, tdim);
   assert(f_to_c);
-  _mesh->topology().create_connectivity(tdim, tdim - 1);
+  _mesh->topology_mutable().create_connectivity(tdim, tdim - 1);
   auto c_to_f = _mesh->topology().connectivity(tdim, tdim - 1);
   assert(c_to_f);
 

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -436,7 +436,7 @@ void dolfinx_contact::evaluate_basis_functions(
     apply_dof_transformation(
         xtl::span(basis_reference_values.data() + p * num_basis_values,
                   num_basis_values),
-        cell_info, cell_index, reference_value_size);
+        cell_info, cell_index, (int)reference_value_size);
 
     // Push basis forward to physical element
     auto _K = xt::view(K, p, xt::all(), xt::all());

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -286,19 +286,20 @@ void dolfinx_contact::evaluate_basis_functions(
   // Get mesh
   std::shared_ptr<const dolfinx::mesh::Mesh> mesh = V.mesh();
   assert(mesh);
-  const std::size_t gdim = mesh->geometry().dim();
-  const std::size_t tdim = mesh->topology().dim();
-  auto map = mesh->topology().index_map((int)tdim);
+  const dolfinx::mesh::Geometry& geometry = mesh->geometry();
+  const dolfinx::mesh::Topology& topology = mesh->topology();
+
+  // Get topology data
+  const std::size_t tdim = topology.dim();
+  auto map = topology.index_map((int)tdim);
 
   // Get geometry data
+  const std::size_t gdim = geometry.dim();
+  xtl::span<const double> x_g = geometry.x();
   const dolfinx::graph::AdjacencyList<std::int32_t>& x_dofmap
-      = mesh->geometry().dofmap();
-  // FIXME: Add proper interface for num coordinate dofs
-  const std::size_t num_dofs_g = x_dofmap.num_links(0);
-  xtl::span<const double> x_g = mesh->geometry().x();
-
-  // Get coordinate map
-  const dolfinx::fem::CoordinateElement& cmap = mesh->geometry().cmap();
+      = geometry.dofmap();
+  const dolfinx::fem::CoordinateElement& cmap = geometry.cmap();
+  const std::size_t num_dofs_g = cmap.dim();
 
   // Get element
   assert(V.element());
@@ -326,7 +327,7 @@ void dolfinx_contact::evaluate_basis_functions(
   if (element->needs_dof_transformations())
   {
     mesh->topology_mutable().create_entity_permutations();
-    cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    cell_info = xtl::span(topology.get_cell_permutation_info());
   }
 
   xt::xtensor<double, 2> coordinate_dofs


### PR DESCRIPTION
- Use topology and geometry references for more readable code
- Use cmap.dim() instead of links(0).
- Fix bug in accessing permutations before creating them