### PR TITLE
Improvements to onsided kernels

### DIFF
--- a/cpp/Contact.h
+++ b/cpp/Contact.h
@@ -23,7 +23,7 @@
 #include <dolfinx_cuas/utils.hpp>
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xindex_view.hpp>
-#include <xtensor/xio.hpp>
+
 using contact_kernel_fn = std::function<void(
     std::vector<std::vector<PetscScalar>>&, const double*, const double*,
     const double*, const int*, const std::uint8_t*, const std::size_t)>;

--- a/cpp/coefficients.cpp
+++ b/cpp/coefficients.cpp
@@ -350,8 +350,9 @@ std::pair<std::vector<PetscScalar>, int> dolfinx_contact::pack_circumradius(
     detJ[0] = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(_J);
 
     // Sum up quadrature contributions
-    // NOTE: Consider refactoring (moving in Jacobian computation when we start
-    // supporting non-affine geoemtries)
+
+    // NOTE: Consider refactoring (moving in Jacobian computation when we
+    // start supporting non-affine geometries)
     circumradius.push_back(
         compute_circumradius(mesh, detJ[0], coordinate_dofs));
   }

--- a/cpp/contact_kernels.hpp
+++ b/cpp/contact_kernels.hpp
@@ -142,8 +142,9 @@ dolfinx_cuas::kernel_fn<T> generate_contact_kernel(
   // Get facet normals on reference cell
   auto facet_normals = basix::cell::facet_outward_normals(basix_cell);
 
-  auto update_jacobian = get_update_jacobian_dependencies(cmap);
-  auto update_normal = get_update_normal(cmap);
+  auto update_jacobian
+      = dolfinx_contact::get_update_jacobian_dependencies(cmap);
+  auto update_normal = dolfinx_contact::get_update_normal(cmap);
   const bool affine = cmap.is_affine();
   // Define kernels
   // RHS for contact with rigid surface

--- a/cpp/geometric_quantities.cpp
+++ b/cpp/geometric_quantities.cpp
@@ -75,20 +75,10 @@ xt::xtensor<double, 2> dolfinx_contact::push_forward_facet_normal(
   xt::xtensor<double, 2> normals = xt::zeros<double>({num_points, gdim});
   for (std::size_t q = 0; q < num_points; ++q)
   {
-    // Compute normal of physical facet using a normalized covariant Piola
-    // transform n_phys = J^{-T} n_ref / ||J^{-T} n_ref|| See for instance
-    // DOI: 10.1137/08073901X
-    auto _K = xt::view(K, q, xt::all(), xt::all());
-    auto facet_normal = xt::row(reference_normals, facet_indices[q]);
-    for (std::size_t i = 0; i < gdim; i++)
-    {
-      for (std::size_t j = 0; j < tdim; j++)
-        normals(q, i) += _K(j, i) * facet_normal[j];
-    }
-    // Normalize vector
-    auto n_q = xt::row(normals, q);
-    auto n_norm = xt::norm_l2(n_q);
-    n_q /= n_norm;
+    // Push forward reference facet normal
+    physical_facet_normal(xt::row(normals, q),
+                          xt::view(K, q, xt::all(), xt::all()),
+                          xt::row(reference_normals, facet_indices[q]));
   }
   return normals;
 }

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -143,4 +143,26 @@ double compute_facet_jacobians(int q, const xt::xtensor<double, 3>& dphi,
                                xt::xtensor<double, 2>& K,
                                xt::xtensor<double, 2>& J_tot);
 
+/// @brief Convenience function to update Jacobians
+///
+/// For affine geometries, the input determinant is returned.
+/// For non-affine geometries, the Jacobian, it's inverse and the total Jacobian
+/// (J*J_f) is computed.
+/// @param[in] cmap The coordinate element
+std::function<double(std::size_t, const xt::xtensor<double, 3>&,
+                     const xt::xtensor<double, 2>&,
+                     const xt::xtensor<double, 2>&, xt::xtensor<double, 2>&,
+                     xt::xtensor<double, 2>&, xt::xtensor<double, 2>&, double&)>
+get_update_jacobian_dependencies(const dolfinx::fem::CoordinateElement& cmap);
+
+/// @brief Convenience function to update facet normals
+///
+/// For affine geometries, a do nothing function is returned.
+/// For non-affine geometries, a function updating the physical facet normal is
+/// returned.
+/// @param[in] cmap The coordinate element
+std::function<void(xt::xtensor<double, 1>&, const xt::xtensor<double, 2>&,
+                   const xt::xtensor<double, 2>&, std::size_t)>
+get_update_normal(const dolfinx::fem::CoordinateElement& cmap);
+
 } // namespace dolfinx_contact

--- a/python/demos/demo_nitsche_rigid_surface_cuas.py
+++ b/python/demos/demo_nitsche_rigid_surface_cuas.py
@@ -130,10 +130,10 @@ if __name__ == "__main__":
         else:
             fname = "twomeshes"
             if simplex:
-                create_circle_plane_mesh(filename=f"{fname}.msh")
+                create_circle_plane_mesh(filename=f"{fname}.msh", res=0.05)
                 convert_mesh(fname, f"{fname}.xdmf", "triangle", prune_z=True)
             else:
-                create_circle_plane_mesh(filename=f"{fname}.msh", quads=True)
+                create_circle_plane_mesh(filename=f"{fname}.msh", quads=True, res=0.05)
                 convert_mesh(fname, f"{fname}.xdmf", "quad", prune_z=True)
             convert_mesh(fname, f"{fname}_facets.xdmf", "line", prune_z=True)
 
@@ -176,7 +176,7 @@ if __name__ == "__main__":
             facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
 
     # Solver options
-    newton_options = {"relaxation_parameter": 1.0}
+    newton_options = {"relaxation_parameter": 1.0, "max_it": 50}
     # petsc_options = {"ksp_type": "preonly", "pc_type": "lu"}
     petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "rtol": 1e-6, "pc_gamg_coarse_eq_limit": 1000,
                      "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "jacobi",


### PR DESCRIPTION
- Remove usage of Basix element for coordinate element in favor of the dolfinx::mesh::CoordinateElement
- Remove duplication of normal vector computation from kernels (including unbiased contact).
- Remove if-statement inside kernel by fetching function prior to kernel
- Generalize one-sided kernels to non-affine geometries