### PR TITLE
3D ray-tracing

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -46,9 +46,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Workaround until https://github.com/h5py/h5py/pull/2101 is merged
       - name: Install meshio/h5py
         run: |
-          CC=mpicc pip3 install --no-cache-dir --no-binary=h5py h5py meshio
+          pip3 install mpi4py --no-cache-dir --upgrade
+          HDF5_MPI="ON" HDF5_DIR="/usr/local" pip3 install --no-cache-dir --no-binary=h5py git+https://github.com/julesghub/h5py.git@py310-compat-2100 --upgrade
+          pip3 install meshio --no-cache-dir --upgrade
 
       - name: Get Basix and install
         uses: actions/checkout@v2

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -55,7 +55,7 @@ target_link_libraries(dolfinx_contact PUBLIC Basix::basix)
 target_link_libraries(dolfinx_contact PUBLIC dolfinx)
 
 include(GNUInstallDirs)
-install(FILES Contact.h contact_kernels.hpp utils.h coefficients.h geometric_quantities.h SubMesh.h QuadratureRule.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx_contact COMPONENT Development)
+install(FILES Contact.h contact_kernels.hpp utils.h coefficients.h geometric_quantities.h SubMesh.h QuadratureRule.h RayTracing.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx_contact COMPONENT Development)
 
 target_sources(dolfinx_contact PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
@@ -64,6 +64,7 @@ target_sources(dolfinx_contact PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/SubMesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/QuadratureRule.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Contact.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/RayTracing.cpp
   )
 
 # Set target include location (for build and installed)

--- a/cpp/RayTracing.cpp
+++ b/cpp/RayTracing.cpp
@@ -38,8 +38,6 @@ get_3D_parameterization(dolfinx::mesh::CellType cell_type, int facet_index)
 
   const int tdim = dolfinx::mesh::cell_dim(cell_type);
 
-  if (tdim != 3)
-    throw std::invalid_argument("Cell does not have topological dimension 3");
   const int num_facets = dolfinx::mesh::cell_num_entities(cell_type, 2);
   if (facet_index >= num_facets)
     throw std::invalid_argument(

--- a/cpp/RayTracing.cpp
+++ b/cpp/RayTracing.cpp
@@ -48,8 +48,8 @@ get_3D_parameterization(dolfinx::mesh::CellType cell_type, int facet_index)
   const std::vector<std::vector<int>> facets
       = basix::cell::topology(basix_cell)[tdim - 1];
 
-  // Create parameterization function expoiting that the mapping between
-  // reference geoemtries are affine
+  // Create parameterization function exploiting that the mapping between
+  // reference geometries are affine
   std::function<xt::xtensor_fixed<double, xt::xshape<1, 3>>(
       xt::xtensor_fixed<double, xt::xshape<2>>)>
       func = [x, facet = facets[facet_index]](

--- a/cpp/RayTracing.cpp
+++ b/cpp/RayTracing.cpp
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier:    MIT
 
 #include "RayTracing.h"
+#include <dolfinx/common/math.h>
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xio.hpp>
 #include <xtensor/xslice.hpp>
@@ -13,16 +14,20 @@
 
 namespace
 {
+
 /// Get function that parameterizes a facet of a given cell
 /// @param[in] cell_type The cell type
 /// @param[in] facet_index The facet index (local to cell)
 /// @returns Function that computes the coordinate parameterization of the local
 /// facet on the reference cell.
-std::function<std::array<double, 3>(std::array<double, 2>)>
+std::function<xt::xtensor_fixed<double, xt::xshape<1, 3>>(
+    xt::xtensor_fixed<double, xt::xshape<2>>)>
 get_3D_parameterization(dolfinx::mesh::CellType cell_type, int facet_index)
 {
 
-  std::function<std::array<double, 3>(std::array<double, 2>)> func;
+  std::function<xt::xtensor_fixed<double, xt::xshape<1, 3>>(
+      xt::xtensor_fixed<double, xt::xshape<2>>)>
+      func;
   const int tdim = dolfinx::mesh::cell_dim(cell_type);
   const int num_facets = dolfinx::mesh::cell_num_entities(cell_type, tdim - 1);
   if (facet_index >= num_facets)
@@ -34,64 +39,74 @@ get_3D_parameterization(dolfinx::mesh::CellType cell_type, int facet_index)
   case dolfinx::mesh::CellType::tetrahedron:
     if (facet_index == 0)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {xi[0], xi[1], 1 - xi[0] - xi[1]};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{xi[0], xi[1], 1 - xi[0] - xi[1]}};
       };
     }
     else if (facet_index == 1)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {0, xi[0], xi[1]};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{0, xi[0], xi[1]}};
       };
     }
     else if (facet_index == 2)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {xi[0], 0, xi[1]};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{xi[0], 0, xi[1]}};
       };
     }
     else if (facet_index == 3)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {xi[0], xi[1], 0};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{xi[0], xi[1], 0}};
       };
     }
     break;
   case dolfinx::mesh::CellType::hexahedron:
     if (facet_index == 0)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {xi[0], xi[1], 0};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{xi[0], xi[1], 0}};
       };
     }
     else if (facet_index == 1)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {xi[0], 0, xi[1]};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{xi[0], 0, xi[1]}};
       };
     }
     else if (facet_index == 2)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {0, xi[0], xi[1]};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{0, xi[0], xi[1]}};
       };
     }
     else if (facet_index == 3)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {1, xi[0], xi[1]};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{1, xi[0], xi[1]}};
       };
     }
     else if (facet_index == 4)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {xi[0], 1, xi[1]};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{xi[0], 1, xi[1]}};
       };
     }
     else if (facet_index == 5)
     {
-      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
-        return {xi[0], xi[1], 1};
+      func = [](xt::xtensor_fixed<double, xt::xshape<2>> xi)
+          -> xt::xtensor_fixed<double, xt::xshape<1, 3>> {
+        return {{xi[0], xi[1], 1}};
       };
     }
     break;
@@ -106,7 +121,7 @@ get_3D_parameterization(dolfinx::mesh::CellType cell_type, int facet_index)
 /// @param[in] cell_type The cell type
 /// @param[in] facet_index The facet index (local to cell)
 /// @returns The Jacobian of the parameterization
-std::array<std::array<double, 3>, 2>
+xt::xtensor_fixed<double, xt::xshape<3, 2>>
 get_parameterization_jacobian(dolfinx::mesh::CellType cell_type,
                               int facet_index)
 {
@@ -121,39 +136,40 @@ get_parameterization_jacobian(dolfinx::mesh::CellType cell_type,
   {
   case dolfinx::mesh::CellType::tetrahedron:
     if (facet_index == 0)
-      return {{{1, 0, -1}, {0, 1, -1}}};
+      return {{1, 0}, {0, 1}, {-1, -1}};
     else if (facet_index == 1)
-      return {{{0, 1, 0}, {0, 0, 1}}};
+      return {{0, 0}, {1, 0}, {0, 1}};
+
     else if (facet_index == 2)
-      return {{{1, 0, 0}, {0, 0, 1}}};
+      return {{1, 0}, {0, 0}, {0, 1}};
     else if (facet_index == 3)
-      return {{{1, 0, 0}, {0, 1, 0}}};
+      return {{1, 0}, {0, 1}, {0, 0}};
     break;
   case dolfinx::mesh::CellType::hexahedron:
     if ((facet_index == 0) or (facet_index == 5))
-      return {{{1, 0, 0}, {0, 1, 0}}};
+      return {{1, 0}, {0, 1}, {0, 0}};
     else if ((facet_index == 1) or (facet_index == 4))
-      return {{{1, 0, 0}, {0, 0, 1}}};
+      return {{1, 0}, {0, 0}, {0, 1}};
     else if ((facet_index == 2) or (facet_index) == 3)
-      return {{{0, 1, 0}, {0, 0, 1}}};
+      return {{0, 0}, {1, 0}, {0, 1}};
     break;
   default:
     throw std::invalid_argument("Unsupported cell type");
     break;
   }
-  std::array<std::array<double, 3>, 2> output;
+  xt::xtensor_fixed<double, xt::xshape<3, 2>> output;
   return output;
 }
 
 } // namespace
 
-std::tuple<int, std::array<double, 3>, std::array<double, 3>>
-dolfinx_contact::compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
-                                const std::array<double, 3>& point,
-                                const std::array<double, 3>& t1,
-                                const std::array<double, 3>& t2, int cell,
-                                int facet_index, const int max_iter,
-                                const double tol)
+std::tuple<int, xt::xtensor_fixed<double, xt::xshape<3>>,
+           xt::xtensor_fixed<double, xt::xshape<3>>>
+dolfinx_contact::compute_3D_ray(
+    const dolfinx::mesh::Mesh& mesh,
+    const xt::xtensor_fixed<double, xt::xshape<3>>& point,
+    const xt::xtensor_fixed<double, xt::xshape<2, 3>>& tangents, int cell,
+    int facet_index, const int max_iter, const double tol)
 {
   int status = -1;
   dolfinx::mesh::CellType cell_type = mesh.topology().cell_type();
@@ -161,7 +177,7 @@ dolfinx_contact::compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
 
   // Get parameterization function and jacobian
   auto xi = get_3D_parameterization(cell_type, facet_index);
-  std::array<std::array<double, 3>, 2> dxi
+  xt::xtensor_fixed<double, xt::xshape<3, 2>> dxi
       = get_parameterization_jacobian(cell_type, facet_index);
 
   const dolfinx::fem::CoordinateElement& cmap = mesh.geometry().cmap();
@@ -182,21 +198,29 @@ dolfinx_contact::compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
     std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), 3,
                 std::next(coordinate_dofs.begin(), j * 3));
   }
-
+  if ((gdim != tdim) or (gdim != 3))
+  {
+    throw std::invalid_argument(
+        "This raytracing algorithm is specialized for meshes with topological "
+        "and geometrical dimension 3");
+  }
+  std::cout << "cell coords " << coordinate_dofs << "\n";
   // Temporary variables
   xt::xtensor<double, 2> X_k({1, 3});
   xt::xtensor<double, 2> x_k({1, 3});
-  std::array<double, 2> xi_k = {0.5, 0.25};
-  std::array<double, 3> x;
-  std::array<double, 3> X;
-  xt::xtensor<double, 2> J({(std::size_t)gdim, (std::size_t)tdim});
+  xt::xtensor_fixed<double, xt::xshape<2>> xi_k = {0.5, 0.25};
+  xt::xtensor_fixed<double, xt::xshape<2>> dxi_k;
+
+  xt::xtensor_fixed<double, xt::xshape<3, 3>> J;
   xt::xtensor<double, 2> dphi({(std::size_t)tdim, num_dofs_g});
-  std::array<double, 2> G_k;
+  xt::xtensor_fixed<double, xt::xshape<3, 2>> dGk_tmp;
+  xt::xtensor_fixed<double, xt::xshape<2, 2>> dGk;
+  xt::xtensor_fixed<double, xt::xshape<2, 2>> dGk_inv;
+  xt::xtensor_fixed<double, xt::xshape<2>> Gk;
   for (int k = 0; k < max_iter; ++k)
   {
     // Evaluate reference coordinate at current iteration
-    X = xi(xi_k);
-    std::copy(X.cbegin(), X.cend(), X_k.begin());
+    X_k = xi(xi_k);
 
     // Tabulate coordinate element basis function
     cmap.tabulate(1, X_k, basis_values);
@@ -207,33 +231,79 @@ dolfinx_contact::compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
     dphi = xt::view(basis_values, xt::xrange(1, tdim + 1), 0, xt::all(), 0);
 
     // Compute Jacobian
+    std::fill(J.begin(), J.end(), 0);
     cmap.compute_jacobian(dphi, coordinate_dofs, J);
 
     // Compute residual at current iteration
-    std::fill(G_k.begin(), G_k.end(), 0);
+    std::fill(Gk.begin(), Gk.end(), 0);
     for (std::size_t i = 0; i < 3; ++i)
     {
-      G_k[0] += (x_k(0, i) - point[i]) * t1[i];
-      G_k[1] += (x_k(0, i) - point[i]) * t2[i];
+      Gk[0] += (x_k(0, i) - point[i]) * tangents(0, i);
+      Gk[1] += (x_k(0, i) - point[i]) * tangents(1, i);
     }
 
     // Check for convergence in first iteration
-    if ((k == 0) and (std::abs(G_k[0]) < tol) and (std::abs(G_k[1]) < tol))
+    if ((k == 0) and (std::abs(Gk[0]) < tol) and (std::abs(Gk[1]) < tol))
       break;
 
-    /// Compute dG_k/dxi
+    /// Compute dGk/dxi
+    std::fill(dGk_tmp.begin(), dGk_tmp.end(), 0);
+    dolfinx::math::dot(J, dxi, dGk_tmp);
+    std::fill(dGk.begin(), dGk.end(), 0);
 
-    // Invert dG_k/dxi
+    for (std::size_t i = 0; i < 2; ++i)
+      for (std::size_t j = 0; j < 2; ++j)
+        for (std::size_t l = 0; l < 3; ++l)
+          dGk(i, j) += dGk_tmp(l, j) * tangents(i, l);
 
-    // Compute dxi and check for convergence
+    // Invert dGk/dxi
+    double det_dGk = dolfinx::math::det(dGk);
+    if (std::abs(det_dGk) < tol)
+    {
+      status = -2;
+      break;
+    }
+    dolfinx::math::inv(dGk, dGk_inv);
+
+    // Compute dxi
+    std::fill(dxi_k.begin(), dxi_k.end(), 0);
+    for (std::size_t i = 0; i < 2; ++i)
+      for (std::size_t j = 0; j < 2; ++j)
+        dxi_k[i] += dGk_inv(i, j) * Gk[j];
+
+    // Check for convergence
+    if ((dxi_k[0] * dxi_k[0] + dxi_k[1] * dxi_k[1]) < tol * tol)
+    {
+      status = 1;
+      break;
+    }
 
     // Update xi
+    std::transform(xi_k.cbegin(), xi_k.cend(), dxi_k.cbegin(), xi_k.begin(),
+                   [](auto x, auto y) { return x - y; });
+  }
+  // Check if converged  parameters are valid
+  switch (cell_type)
+  {
+  case dolfinx::mesh::CellType::tetrahedron:
+    if ((xi_k[0] < 0) or (xi_k[0] > 1) or (xi_k[1] < 0)
+        or (xi_k[1] > 1 - xi_k[0]))
+    {
+      status = -3;
+    }
+    break;
+  case dolfinx::mesh::CellType::hexahedron:
+    if ((xi_k[0] < 0) or (xi_k[0] > 1) or (xi_k[1] < 0) or (xi_k[1] > 1))
+    {
+      status = -3;
+    }
+    break;
+  default:
+    throw std::invalid_argument("Invalid cell type");
   }
 
-  // Check if converged  parameters are valid
-  std::cout << X_k << " " << x_k << "\n";
-  std::cout << xt::adapt(dxi[0]) << "\n;";
-  std::tuple<int, std::array<double, 3>, std::array<double, 3>> output
-      = std::make_tuple(status, x, X);
+  std::tuple<int, xt::xtensor_fixed<double, xt::xshape<3>>,
+             xt::xtensor_fixed<double, xt::xshape<3>>>
+      output = std::make_tuple(status, x_k, X_k);
   return output;
 };

--- a/cpp/RayTracing.cpp
+++ b/cpp/RayTracing.cpp
@@ -8,9 +8,7 @@
 #include "RayTracing.h"
 #include <basix/cell.h>
 #include <dolfinx/common/math.h>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xslice.hpp>
+#include <dolfinx/common/utils.h>
 #include <xtensor/xview.hpp>
 
 namespace
@@ -252,10 +250,10 @@ dolfinx_contact::compute_3D_ray(
     auto [cell, facet_index] = cells[c];
     auto x_dofs = x_dofmap.links(cell);
     for (std::size_t j = 0; j < x_dofs.size(); ++j)
-
     {
-      std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), 3,
-                  std::next(coordinate_dofs.begin(), j * 3));
+      dolfinx::common::impl::copy_N<3>(
+          std::next(x_g.begin(), 3 * x_dofs[j]),
+          std::next(coordinate_dofs.begin(), 3 * j));
     }
 
     // Assign Jacobian of reference mapping

--- a/cpp/RayTracing.cpp
+++ b/cpp/RayTracing.cpp
@@ -163,22 +163,20 @@ get_parameterization_jacobian(dolfinx::mesh::CellType cell_type,
 
 } // namespace
 
-std::tuple<int, xt::xtensor_fixed<double, xt::xshape<3>>,
-           xt::xtensor_fixed<double, xt::xshape<3>>>
+std::tuple<int, std::int32_t, xt::xtensor_fixed<double, xt::xshape<2, 3>>>
 dolfinx_contact::compute_3D_ray(
     const dolfinx::mesh::Mesh& mesh,
     const xt::xtensor_fixed<double, xt::xshape<3>>& point,
-    const xt::xtensor_fixed<double, xt::xshape<2, 3>>& tangents, int cell,
-    int facet_index, const int max_iter, const double tol)
+    const xt::xtensor_fixed<double, xt::xshape<2, 3>>& tangents,
+    const std::vector<std::pair<std::int32_t, int>>& cells, const int max_iter,
+    const double tol)
 {
   int status = -1;
   dolfinx::mesh::CellType cell_type = mesh.topology().cell_type();
   const int tdim = mesh.topology().dim();
 
-  // Get parameterization function and jacobian
-  auto xi = get_3D_parameterization(cell_type, facet_index);
-  xt::xtensor_fixed<double, xt::xshape<3, 2>> dxi
-      = get_parameterization_jacobian(cell_type, facet_index);
+  // Storage for facet derivative
+  xt::xtensor_fixed<double, xt::xshape<3, 2>> dxi;
 
   const dolfinx::fem::CoordinateElement& cmap = mesh.geometry().cmap();
   const std::array<std::size_t, 4> basis_shape = cmap.tabulate_shape(1, 1);
@@ -190,25 +188,20 @@ dolfinx_contact::compute_3D_ray(
       = geometry.dofmap();
   const int gdim = geometry.dim();
   xtl::span<const double> x_g = geometry.x();
-  auto x_dofs = x_dofmap.links(cell);
   const std::size_t num_dofs_g = cmap.dim();
   xt::xtensor<double, 2> coordinate_dofs({num_dofs_g, 3});
-  for (std::size_t j = 0; j < x_dofs.size(); ++j)
-  {
-    std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), 3,
-                std::next(coordinate_dofs.begin(), j * 3));
-  }
+
   if ((gdim != tdim) or (gdim != 3))
   {
     throw std::invalid_argument(
         "This raytracing algorithm is specialized for meshes with topological "
         "and geometrical dimension 3");
   }
-  std::cout << "cell coords " << coordinate_dofs << "\n";
+
   // Temporary variables
   xt::xtensor<double, 2> X_k({1, 3});
   xt::xtensor<double, 2> x_k({1, 3});
-  xt::xtensor_fixed<double, xt::xshape<2>> xi_k = {0.5, 0.25};
+  xt::xtensor_fixed<double, xt::xshape<2>> xi_k;
   xt::xtensor_fixed<double, xt::xshape<2>> dxi_k;
 
   xt::xtensor_fixed<double, xt::xshape<3, 3>> J;
@@ -217,93 +210,128 @@ dolfinx_contact::compute_3D_ray(
   xt::xtensor_fixed<double, xt::xshape<2, 2>> dGk;
   xt::xtensor_fixed<double, xt::xshape<2, 2>> dGk_inv;
   xt::xtensor_fixed<double, xt::xshape<2>> Gk;
-  for (int k = 0; k < max_iter; ++k)
+
+  std::size_t cell_idx = -1;
+
+  for (std::size_t c = 0; c < cells.size(); ++c)
   {
-    // Evaluate reference coordinate at current iteration
-    X_k = xi(xi_k);
 
-    // Tabulate coordinate element basis function
-    cmap.tabulate(1, X_k, basis_values);
+    // Get cell geometry
+    auto [cell, facet_index] = cells[c];
+    auto x_dofs = x_dofmap.links(cell);
+    for (std::size_t j = 0; j < x_dofs.size(); ++j)
 
-    // Push forward reference coordinate
-    cmap.push_forward(x_k, coordinate_dofs,
-                      xt::view(basis_values, 0, xt::all(), xt::all(), 0));
-    dphi = xt::view(basis_values, xt::xrange(1, tdim + 1), 0, xt::all(), 0);
-
-    // Compute Jacobian
-    std::fill(J.begin(), J.end(), 0);
-    cmap.compute_jacobian(dphi, coordinate_dofs, J);
-
-    // Compute residual at current iteration
-    std::fill(Gk.begin(), Gk.end(), 0);
-    for (std::size_t i = 0; i < 3; ++i)
     {
-      Gk[0] += (x_k(0, i) - point[i]) * tangents(0, i);
-      Gk[1] += (x_k(0, i) - point[i]) * tangents(1, i);
+      std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), 3,
+                  std::next(coordinate_dofs.begin(), j * 3));
     }
 
-    // Check for convergence in first iteration
-    if ((k == 0) and (std::abs(Gk[0]) < tol) and (std::abs(Gk[1]) < tol))
-      break;
+    // Get facet parameterization
+    auto xi = get_3D_parameterization(cell_type, facet_index);
 
-    /// Compute dGk/dxi
-    std::fill(dGk_tmp.begin(), dGk_tmp.end(), 0);
-    dolfinx::math::dot(J, dxi, dGk_tmp);
-    std::fill(dGk.begin(), dGk.end(), 0);
+    dxi = get_parameterization_jacobian(cell_type, facet_index);
 
-    for (std::size_t i = 0; i < 2; ++i)
-      for (std::size_t j = 0; j < 2; ++j)
-        for (std::size_t l = 0; l < 3; ++l)
-          dGk(i, j) += dGk_tmp(l, j) * tangents(i, l);
-
-    // Invert dGk/dxi
-    double det_dGk = dolfinx::math::det(dGk);
-    if (std::abs(det_dGk) < tol)
+    // Reset initial guess
+    xi_k = {0.5, 0.25};
+    for (int k = 0; k < max_iter; ++k)
     {
-      status = -2;
+      // Evaluate reference coordinate at current iteration
+      X_k = xi(xi_k);
+
+      // Tabulate coordinate element basis function
+      cmap.tabulate(1, X_k, basis_values);
+
+      // Push forward reference coordinate
+      cmap.push_forward(x_k, coordinate_dofs,
+                        xt::view(basis_values, 0, xt::all(), xt::all(), 0));
+      dphi = xt::view(basis_values, xt::xrange(1, tdim + 1), 0, xt::all(), 0);
+
+      // Compute Jacobian
+      std::fill(J.begin(), J.end(), 0);
+      cmap.compute_jacobian(dphi, coordinate_dofs, J);
+
+      // Compute residual at current iteration
+      std::fill(Gk.begin(), Gk.end(), 0);
+      for (std::size_t i = 0; i < 3; ++i)
+      {
+        Gk[0] += (x_k(0, i) - point[i]) * tangents(0, i);
+        Gk[1] += (x_k(0, i) - point[i]) * tangents(1, i);
+      }
+
+      // Check for convergence in first iteration
+      if ((k == 0) and (std::abs(Gk[0]) < tol) and (std::abs(Gk[1]) < tol))
+        break;
+
+      /// Compute dGk/dxi
+      std::fill(dGk_tmp.begin(), dGk_tmp.end(), 0);
+      dolfinx::math::dot(J, dxi, dGk_tmp);
+      std::fill(dGk.begin(), dGk.end(), 0);
+
+      for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 2; ++j)
+          for (std::size_t l = 0; l < 3; ++l)
+            dGk(i, j) += dGk_tmp(l, j) * tangents(i, l);
+
+      // Invert dGk/dxi
+      double det_dGk = dolfinx::math::det(dGk);
+      if (std::abs(det_dGk) < tol)
+      {
+        status = -2;
+        break;
+      }
+      dolfinx::math::inv(dGk, dGk_inv);
+
+      // Compute dxi
+      std::fill(dxi_k.begin(), dxi_k.end(), 0);
+      for (std::size_t i = 0; i < 2; ++i)
+        for (std::size_t j = 0; j < 2; ++j)
+          dxi_k[i] += dGk_inv(i, j) * Gk[j];
+
+      // Check for convergence
+      if ((dxi_k[0] * dxi_k[0] + dxi_k[1] * dxi_k[1]) < tol * tol)
+      {
+        status = 1;
+        break;
+      }
+
+      // Update xi
+      std::transform(xi_k.cbegin(), xi_k.cend(), dxi_k.cbegin(), xi_k.begin(),
+                     [](auto x, auto y) { return x - y; });
+    }
+    // Check if converged  parameters are valid
+    switch (cell_type)
+    {
+    case dolfinx::mesh::CellType::tetrahedron:
+      if ((xi_k[0] < 0) or (xi_k[0] > 1) or (xi_k[1] < 0)
+          or (xi_k[1] > 1 - xi_k[0]))
+      {
+        status = -3;
+      }
+      break;
+    case dolfinx::mesh::CellType::hexahedron:
+      if ((xi_k[0] < 0) or (xi_k[0] > 1) or (xi_k[1] < 0) or (xi_k[1] > 1))
+      {
+        status = -3;
+      }
+      break;
+    default:
+      throw std::invalid_argument("Invalid cell type");
+    }
+
+    if (status > 0)
+    {
+      cell_idx = c;
       break;
     }
-    dolfinx::math::inv(dGk, dGk_inv);
-
-    // Compute dxi
-    std::fill(dxi_k.begin(), dxi_k.end(), 0);
-    for (std::size_t i = 0; i < 2; ++i)
-      for (std::size_t j = 0; j < 2; ++j)
-        dxi_k[i] += dGk_inv(i, j) * Gk[j];
-
-    // Check for convergence
-    if ((dxi_k[0] * dxi_k[0] + dxi_k[1] * dxi_k[1]) < tol * tol)
-    {
-      status = 1;
-      break;
-    }
-
-    // Update xi
-    std::transform(xi_k.cbegin(), xi_k.cend(), dxi_k.cbegin(), xi_k.begin(),
-                   [](auto x, auto y) { return x - y; });
   }
-  // Check if converged  parameters are valid
-  switch (cell_type)
-  {
-  case dolfinx::mesh::CellType::tetrahedron:
-    if ((xi_k[0] < 0) or (xi_k[0] > 1) or (xi_k[1] < 0)
-        or (xi_k[1] > 1 - xi_k[0]))
-    {
-      status = -3;
-    }
-    break;
-  case dolfinx::mesh::CellType::hexahedron:
-    if ((xi_k[0] < 0) or (xi_k[0] > 1) or (xi_k[1] < 0) or (xi_k[1] > 1))
-    {
-      status = -3;
-    }
-    break;
-  default:
-    throw std::invalid_argument("Invalid cell type");
-  }
+  if (status < 0)
+    LOG(WARNING) << "No ray through the facets have been found";
 
-  std::tuple<int, xt::xtensor_fixed<double, xt::xshape<3>>,
-             xt::xtensor_fixed<double, xt::xshape<3>>>
-      output = std::make_tuple(status, x_k, X_k);
+  xt::xtensor_fixed<double, xt::xshape<2, 3>> output_coords;
+  std::copy(x_k.cbegin(), x_k.cend(), output_coords.begin());
+  std::copy(X_k.cbegin(), X_k.cend(), std::next(output_coords.begin(), 3));
+
+  std::tuple<int, std::int32_t, xt::xtensor_fixed<double, xt::xshape<2, 3>>>
+      output = std::make_tuple(status, cell_idx, output_coords);
   return output;
 };

--- a/cpp/RayTracing.cpp
+++ b/cpp/RayTracing.cpp
@@ -1,0 +1,25 @@
+
+// Copyright (C) 2022 Jørgen S. Dokken
+//
+// This file is part of DOLFINx_CONTACT
+//
+// SPDX-License-Identifier:    MIT
+
+#include "RayTracing.h"
+
+std::tuple<int, std::array<double, 3>, std::array<double, 3>>
+dolfinx_contact::compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
+                                const std::array<double, 3>& point,
+                                const std::array<double, 3>& t1,
+                                const std::array<double, 3>& t2, int cell,
+                                int facet_index, const int max_iter,
+                                const double tol)
+{
+  int status = -1;
+  std::array<double, 3> x_k;
+  std::array<double, 3> X_k;
+
+  std::tuple<int, std::array<double, 3>, std::array<double, 3>> output
+      = std::make_tuple(status, x_k, X_k);
+  return output;
+};

--- a/cpp/RayTracing.cpp
+++ b/cpp/RayTracing.cpp
@@ -6,6 +6,146 @@
 // SPDX-License-Identifier:    MIT
 
 #include "RayTracing.h"
+#include <xtensor/xadapt.hpp>
+#include <xtensor/xio.hpp>
+#include <xtensor/xslice.hpp>
+#include <xtensor/xview.hpp>
+
+namespace
+{
+/// Get function that parameterizes a facet of a given cell
+/// @param[in] cell_type The cell type
+/// @param[in] facet_index The facet index (local to cell)
+/// @returns Function that computes the coordinate parameterization of the local
+/// facet on the reference cell.
+std::function<std::array<double, 3>(std::array<double, 2>)>
+get_3D_parameterization(dolfinx::mesh::CellType cell_type, int facet_index)
+{
+
+  std::function<std::array<double, 3>(std::array<double, 2>)> func;
+  const int tdim = dolfinx::mesh::cell_dim(cell_type);
+  const int num_facets = dolfinx::mesh::cell_num_entities(cell_type, tdim - 1);
+  if (facet_index >= num_facets)
+    throw std::invalid_argument(
+        "Invalid facet index (larger than number of facets");
+
+  switch (cell_type)
+  {
+  case dolfinx::mesh::CellType::tetrahedron:
+    if (facet_index == 0)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {xi[0], xi[1], 1 - xi[0] - xi[1]};
+      };
+    }
+    else if (facet_index == 1)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {0, xi[0], xi[1]};
+      };
+    }
+    else if (facet_index == 2)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {xi[0], 0, xi[1]};
+      };
+    }
+    else if (facet_index == 3)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {xi[0], xi[1], 0};
+      };
+    }
+    break;
+  case dolfinx::mesh::CellType::hexahedron:
+    if (facet_index == 0)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {xi[0], xi[1], 0};
+      };
+    }
+    else if (facet_index == 1)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {xi[0], 0, xi[1]};
+      };
+    }
+    else if (facet_index == 2)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {0, xi[0], xi[1]};
+      };
+    }
+    else if (facet_index == 3)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {1, xi[0], xi[1]};
+      };
+    }
+    else if (facet_index == 4)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {xi[0], 1, xi[1]};
+      };
+    }
+    else if (facet_index == 5)
+    {
+      func = [](std::array<double, 2> xi) -> std::array<double, 3> {
+        return {xi[0], xi[1], 1};
+      };
+    }
+    break;
+  default:
+    throw std::invalid_argument("Unsupported cell type");
+    break;
+  }
+  return func;
+}
+
+/// Get derivative of the parameterization with respect to the input parameters
+/// @param[in] cell_type The cell type
+/// @param[in] facet_index The facet index (local to cell)
+/// @returns The Jacobian of the parameterization
+std::array<std::array<double, 3>, 2>
+get_parameterization_jacobian(dolfinx::mesh::CellType cell_type,
+                              int facet_index)
+{
+
+  const int tdim = dolfinx::mesh::cell_dim(cell_type);
+  const int num_facets = dolfinx::mesh::cell_num_entities(cell_type, tdim - 1);
+  if (facet_index >= num_facets)
+    throw std::invalid_argument(
+        "Invalid facet index (larger than number of facets");
+
+  switch (cell_type)
+  {
+  case dolfinx::mesh::CellType::tetrahedron:
+    if (facet_index == 0)
+      return {{{1, 0, -1}, {0, 1, -1}}};
+    else if (facet_index == 1)
+      return {{{0, 1, 0}, {0, 0, 1}}};
+    else if (facet_index == 2)
+      return {{{1, 0, 0}, {0, 0, 1}}};
+    else if (facet_index == 3)
+      return {{{1, 0, 0}, {0, 1, 0}}};
+    break;
+  case dolfinx::mesh::CellType::hexahedron:
+    if ((facet_index == 0) or (facet_index == 5))
+      return {{{1, 0, 0}, {0, 1, 0}}};
+    else if ((facet_index == 1) or (facet_index == 4))
+      return {{{1, 0, 0}, {0, 0, 1}}};
+    else if ((facet_index == 2) or (facet_index) == 3)
+      return {{{0, 1, 0}, {0, 0, 1}}};
+    break;
+  default:
+    throw std::invalid_argument("Unsupported cell type");
+    break;
+  }
+  std::array<std::array<double, 3>, 2> output;
+  return output;
+}
+
+} // namespace
 
 std::tuple<int, std::array<double, 3>, std::array<double, 3>>
 dolfinx_contact::compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
@@ -16,10 +156,84 @@ dolfinx_contact::compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
                                 const double tol)
 {
   int status = -1;
-  std::array<double, 3> x_k;
-  std::array<double, 3> X_k;
+  dolfinx::mesh::CellType cell_type = mesh.topology().cell_type();
+  const int tdim = mesh.topology().dim();
 
+  // Get parameterization function and jacobian
+  auto xi = get_3D_parameterization(cell_type, facet_index);
+  std::array<std::array<double, 3>, 2> dxi
+      = get_parameterization_jacobian(cell_type, facet_index);
+
+  const dolfinx::fem::CoordinateElement& cmap = mesh.geometry().cmap();
+  const std::array<std::size_t, 4> basis_shape = cmap.tabulate_shape(1, 1);
+  xt::xtensor<double, 4> basis_values(basis_shape);
+
+  // Get cell coordinates/geometry
+  const dolfinx::mesh::Geometry& geometry = mesh.geometry();
+  const dolfinx::graph::AdjacencyList<std::int32_t>& x_dofmap
+      = geometry.dofmap();
+  const int gdim = geometry.dim();
+  xtl::span<const double> x_g = geometry.x();
+  auto x_dofs = x_dofmap.links(cell);
+  const std::size_t num_dofs_g = cmap.dim();
+  xt::xtensor<double, 2> coordinate_dofs({num_dofs_g, 3});
+  for (std::size_t j = 0; j < x_dofs.size(); ++j)
+  {
+    std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), 3,
+                std::next(coordinate_dofs.begin(), j * 3));
+  }
+
+  // Temporary variables
+  xt::xtensor<double, 2> X_k({1, 3});
+  xt::xtensor<double, 2> x_k({1, 3});
+  std::array<double, 2> xi_k = {0.5, 0.25};
+  std::array<double, 3> x;
+  std::array<double, 3> X;
+  xt::xtensor<double, 2> J({(std::size_t)gdim, (std::size_t)tdim});
+  xt::xtensor<double, 2> dphi({(std::size_t)tdim, num_dofs_g});
+  std::array<double, 2> G_k;
+  for (int k = 0; k < max_iter; ++k)
+  {
+    // Evaluate reference coordinate at current iteration
+    X = xi(xi_k);
+    std::copy(X.cbegin(), X.cend(), X_k.begin());
+
+    // Tabulate coordinate element basis function
+    cmap.tabulate(1, X_k, basis_values);
+
+    // Push forward reference coordinate
+    cmap.push_forward(x_k, coordinate_dofs,
+                      xt::view(basis_values, 0, xt::all(), xt::all(), 0));
+    dphi = xt::view(basis_values, xt::xrange(1, tdim + 1), 0, xt::all(), 0);
+
+    // Compute Jacobian
+    cmap.compute_jacobian(dphi, coordinate_dofs, J);
+
+    // Compute residual at current iteration
+    std::fill(G_k.begin(), G_k.end(), 0);
+    for (std::size_t i = 0; i < 3; ++i)
+    {
+      G_k[0] += (x_k(0, i) - point[i]) * t1[i];
+      G_k[1] += (x_k(0, i) - point[i]) * t2[i];
+    }
+
+    // Check for convergence in first iteration
+    if ((k == 0) and (std::abs(G_k[0]) < tol) and (std::abs(G_k[1]) < tol))
+      break;
+
+    /// Compute dG_k/dxi
+
+    // Invert dG_k/dxi
+
+    // Compute dxi and check for convergence
+
+    // Update xi
+  }
+
+  // Check if converged  parameters are valid
+  std::cout << X_k << " " << x_k << "\n";
+  std::cout << xt::adapt(dxi[0]) << "\n;";
   std::tuple<int, std::array<double, 3>, std::array<double, 3>> output
-      = std::make_tuple(status, x_k, X_k);
+      = std::make_tuple(status, x, X);
   return output;
 };

--- a/cpp/RayTracing.h
+++ b/cpp/RayTracing.h
@@ -1,0 +1,43 @@
+
+// Copyright (C) 2021 Jørgen S. Dokken
+//
+// This file is part of DOLFINx_CONTACT
+//
+// SPDX-License-Identifier:    MIT
+
+#pragma once
+
+#include <dolfinx/mesh/Mesh.h>
+
+namespace dolfinx_contact
+{
+
+/// @brief Compute the intersection between a ray and a facet in the mesh.
+///
+/// The implementation solves dot(\Phi(\xi, \eta)-p, t_i)=0, i=1,2
+/// where \Phi(\xi,\eta) is the parameterized mapping from the reference facet
+/// to the physical facet, p the point of origin of the ray, and t_1, t_2 the
+/// two tangents defining the ray.
+///
+/// @note The problem is solved using Newton's method
+///
+/// @param[in] mesh The mesh
+/// @param[in] point The point of origin for the ray
+/// @param[in] t1 The first tangent of the ray
+/// @param[in] t2 The second tangent of the ray
+/// @param[in] cell The cell index (local to process)
+/// @param[in] facet_index The facet index (local to cell)
+/// @param[in] max_iter The maximum number of iterations to use for Newton's
+/// method
+/// @param[in] tol The tolerance for convergence in Newton's method
+/// @returns A triplet (status, x, X), where x is the convergence status, x the
+/// point in physical space, X the point in the reference cell.
+/// @note The convergence status is >0 if converging, -1 if the facet is if the
+/// maximum number of iterations are reached, -2 if the facet is parallel with
+/// the tangent, -3 if the Newton solver finds a solution outside the element.
+std::tuple<int, std::array<double, 3>, std::array<double, 3>> compute_3D_ray(
+    const dolfinx::mesh::Mesh& mesh, const std::array<double, 3>& point,
+    const std::array<double, 3>& t1, const std::array<double, 3>& t2, int cell,
+    int facet_index, const int max_iter = 25, const double tol = 1e-8);
+
+} // namespace dolfinx_contact

--- a/cpp/RayTracing.h
+++ b/cpp/RayTracing.h
@@ -8,16 +8,67 @@
 #pragma once
 
 #include <dolfinx/mesh/Mesh.h>
+#include <xtensor/xtensor.hpp>
 
 namespace dolfinx_contact
 {
+struct newton_3D_storage
+{
+  xt::xtensor_fixed<double, xt::xshape<3, 2>>
+      dxi; // Jacobian of reference mapping
+  xt::xtensor<double, 2>
+      X_k; // Solution on reference domain (for Newton solver)
+  xt::xtensor<double, 2> x_k; // Solution in physical space (for Newton solver)
+  xt::xtensor_fixed<double, xt::xshape<2>>
+      xi_k; // Reference parameters (for Newton solver)
+  xt::xtensor_fixed<double, xt::xshape<2>>
+      dxi_k; // Gradient of reference parameters (for Newton Solver)
+  xt::xtensor_fixed<double, xt::xshape<3, 3>> J; // Jacobian of the cell
+  xt::xtensor_fixed<double, xt::xshape<3, 2>>
+      dGk_tmp; // Temporary variable to invert Jacobian of Newton solver LHS
+  xt::xtensor_fixed<double, xt::xshape<2, 2>> dGk; // Newton solver LHS Jacobian
+  xt::xtensor_fixed<double, xt::xshape<2, 2>>
+      dGk_inv; // Inverse of Newton solver LHS Jacobian
+  xt::xtensor_fixed<double, xt::xshape<2>>
+      Gk; // Residual (RHS) of Newton solver
+  xt::xtensor_fixed<double, xt::xshape<2, 3>> tangents; // Tangents of ray
+  xt::xtensor_fixed<double, xt::xshape<3>> point; // Point of origin for ray
+};
+
+/// @brief Compute raytracing with no dynamic memory allocation
+///
+/// Implementation of 3D ray-tracing, using no dynamic memory allocation
+///
+/// @param[in,out] storage Structure holding all memory required for
+/// the newton iteration.
+/// @note It is expected that the variables tangents, point, xi is filled with
+/// appropriate values
+/// @param[in, out] basis_values Four-dimensional array to write basis values
+/// into.
+/// @param[in, out] dphi Two-dimensional matrix to write the derviative of the
+/// basis functions into
+/// @param[in] max_iter Maximum number of iterations for the Newton solver
+/// @param[in] tol The tolerance for termination of the Newton solver
+/// @param[in] cmap The coordinate element
+/// @param[in] cell_type The cell type of the mesh
+/// @param[in] coordinate_dofs The cell geometry
+/// @param[in] reference_map Function mapping from reference parameters (xi,
+/// eta) to the physical element
+int allocated_3D_ray_tracing(
+    newton_3D_storage& storage, xt::xtensor<double, 4>& basis_values,
+    xt::xtensor<double, 2>& dphi, int max_iter, double tol,
+    const dolfinx::fem::CoordinateElement& cmap,
+    dolfinx::mesh::CellType cell_type,
+    const xt::xtensor<double, 2>& coordinate_dofs,
+    const std::function<xt::xtensor_fixed<double, xt::xshape<1, 3>>(
+        xt::xtensor_fixed<double, xt::xshape<2>>)>& reference_map);
 
 /// @brief Compute the intersection between a ray and a facet in the mesh.
 ///
 /// The implementation solves dot(\Phi(\xi, \eta)-p, t_i)=0, i=1,2
-/// where \Phi(\xi,\eta) is the parameterized mapping from the reference facet
-/// to the physical facet, p the point of origin of the ray, and t_1, t_2 the
-/// two tangents defining the ray. For more details, see
+/// where \Phi(\xi,\eta) is the parameterized mapping from the reference
+/// facet to the physical facet, p the point of origin of the ray, and t_1,
+/// t_2 the two tangents defining the ray. For more details, see
 /// DOI: 10.1016/j.compstruc.2015.02.027 (eq 14).
 ///
 /// @note The problem is solved using Newton's method
@@ -26,17 +77,19 @@ namespace dolfinx_contact
 /// @param[in] point The point of origin for the ray
 /// @param[in] tangents The tangents of the ray. Each row corresponds to a
 /// tangent.
-/// @param[in] cells List of tuples (cell, facet), where the cell index is local
-/// to process and the facet index is local to the cell cell
+/// @param[in] cells List of tuples (cell, facet), where the cell index is
+/// local to process and the facet index is local to the cell cell
 /// @param[in] max_iter The maximum number of iterations to use for Newton's
 /// method
 /// @param[in] tol The tolerance for convergence in Newton's method
-/// @returns A triplet (status, cell_idx, points), where x is the convergence
-/// status, cell_idx is which entry in the input list the ray goes through
-/// and point is the collision point in global and reference coordinates.
-/// @note The convergence status is >0 if converging, -1 if the facet is if the
-/// maximum number of iterations are reached, -2 if the facet is parallel with
-/// the tangent, -3 if the Newton solver finds a solution outside the element.
+/// @returns A triplet (status, cell_idx, points), where x is the
+/// convergence status, cell_idx is which entry in the input list the ray
+/// goes through and point is the collision point in global and reference
+/// coordinates.
+/// @note The convergence status is >0 if converging, -1 if the facet is if
+/// the maximum number of iterations are reached, -2 if the facet is
+/// parallel with the tangent, -3 if the Newton solver finds a solution
+/// outside the element.
 std::tuple<int, std::int32_t, xt::xtensor_fixed<double, xt::xshape<2, 3>>>
 compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
                const xt::xtensor_fixed<double, xt::xshape<3>>& point,

--- a/cpp/RayTracing.h
+++ b/cpp/RayTracing.h
@@ -26,22 +26,22 @@ namespace dolfinx_contact
 /// @param[in] point The point of origin for the ray
 /// @param[in] tangents The tangents of the ray. Each row corresponds to a
 /// tangent.
-/// @param[in] cell The cell index (local to process)
-/// @param[in] facet_index The facet index (local to cell)
+/// @param[in] cells List of tuples (cell, facet), where the cell index is local
+/// to process and the facet index is local to the cell cell
 /// @param[in] max_iter The maximum number of iterations to use for Newton's
 /// method
 /// @param[in] tol The tolerance for convergence in Newton's method
-/// @returns A triplet (status, x, X), where x is the convergence status, x the
-/// point in physical space, X the point in the reference cell.
+/// @returns A triplet (status, cell_idx, points), where x is the convergence
+/// status, cell_idx is which entry in the input list the ray goes through
+/// and point is the collision point in global and reference coordinates.
 /// @note The convergence status is >0 if converging, -1 if the facet is if the
 /// maximum number of iterations are reached, -2 if the facet is parallel with
 /// the tangent, -3 if the Newton solver finds a solution outside the element.
-std::tuple<int, xt::xtensor_fixed<double, xt::xshape<3>>,
-           xt::xtensor_fixed<double, xt::xshape<3>>>
+std::tuple<int, std::int32_t, xt::xtensor_fixed<double, xt::xshape<2, 3>>>
 compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
                const xt::xtensor_fixed<double, xt::xshape<3>>& point,
                const xt::xtensor_fixed<double, xt::xshape<2, 3>>& tangents,
-               int cell, int facet_index, const int max_iter = 25,
-               const double tol = 1e-8);
+               const std::vector<std::pair<std::int32_t, int>>& cells,
+               const int max_iter = 25, const double tol = 1e-8);
 
 } // namespace dolfinx_contact

--- a/cpp/RayTracing.h
+++ b/cpp/RayTracing.h
@@ -17,14 +17,15 @@ namespace dolfinx_contact
 /// The implementation solves dot(\Phi(\xi, \eta)-p, t_i)=0, i=1,2
 /// where \Phi(\xi,\eta) is the parameterized mapping from the reference facet
 /// to the physical facet, p the point of origin of the ray, and t_1, t_2 the
-/// two tangents defining the ray.
+/// two tangents defining the ray. For more details, see
+/// DOI: 10.1016/j.compstruc.2015.02.027 (eq 14).
 ///
 /// @note The problem is solved using Newton's method
 ///
 /// @param[in] mesh The mesh
 /// @param[in] point The point of origin for the ray
-/// @param[in] t1 The first tangent of the ray
-/// @param[in] t2 The second tangent of the ray
+/// @param[in] tangents The tangents of the ray. Each row corresponds to a
+/// tangent.
 /// @param[in] cell The cell index (local to process)
 /// @param[in] facet_index The facet index (local to cell)
 /// @param[in] max_iter The maximum number of iterations to use for Newton's
@@ -35,9 +36,12 @@ namespace dolfinx_contact
 /// @note The convergence status is >0 if converging, -1 if the facet is if the
 /// maximum number of iterations are reached, -2 if the facet is parallel with
 /// the tangent, -3 if the Newton solver finds a solution outside the element.
-std::tuple<int, std::array<double, 3>, std::array<double, 3>> compute_3D_ray(
-    const dolfinx::mesh::Mesh& mesh, const std::array<double, 3>& point,
-    const std::array<double, 3>& t1, const std::array<double, 3>& t2, int cell,
-    int facet_index, const int max_iter = 25, const double tol = 1e-8);
+std::tuple<int, xt::xtensor_fixed<double, xt::xshape<3>>,
+           xt::xtensor_fixed<double, xt::xshape<3>>>
+compute_3D_ray(const dolfinx::mesh::Mesh& mesh,
+               const xt::xtensor_fixed<double, xt::xshape<3>>& point,
+               const xt::xtensor_fixed<double, xt::xshape<2, 3>>& tangents,
+               int cell, int facet_index, const int max_iter = 25,
+               const double tol = 1e-8);
 
 } // namespace dolfinx_contact

--- a/python/dolfinx_contact/wrappers.cpp
+++ b/python/dolfinx_contact/wrappers.cpp
@@ -11,6 +11,7 @@
 #include <dolfinx/mesh/MeshTags.h>
 #include <dolfinx_contact/Contact.h>
 #include <dolfinx_contact/QuadratureRule.h>
+#include <dolfinx_contact/RayTracing.h>
 #include <dolfinx_contact/coefficients.h>
 #include <dolfinx_contact/contact_kernels.hpp>
 #include <dolfinx_contact/utils.h>
@@ -346,4 +347,6 @@ PYBIND11_MODULE(cpp, m)
             active_entities);
         return output;
       });
+
+  m.def("compute_3D_ray", &dolfinx_contact::compute_3D_ray);
 }

--- a/python/tests/test_raytracing.py
+++ b/python/tests/test_raytracing.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2022 Jørgen S. Dokken
+#
+# SPDX-License-Identifier:    MIT
+#
+# This test check that the ray-tracing routines give the same result as the closest point projection
+# when a solution is found (It is not guaranteed that a ray hits the mesh on all processes in parallel)
+
+import dolfinx_contact
+from mpi4py import MPI
+import dolfinx
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("cell_type", [dolfinx.mesh.CellType.hexahedron, dolfinx.mesh.CellType.tetrahedron])
+def test_raytracing(cell_type):
+    origin = [0.51, 0.33, -1]
+    tangent = [[1, 0, 0], [0, 1, 0]]
+
+    mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 15, 15, 15, cell_type)
+    tdim = mesh.topology.dim
+    facets = dolfinx.mesh.locate_entities_boundary(mesh, tdim - 1, lambda x: np.isclose(x[2], 0))
+
+    integral_pairs = dolfinx_contact.cpp.compute_active_entities(mesh, facets, dolfinx.fem.IntegralType.exterior_facet)
+
+    status, cell_idx, points = dolfinx_contact.cpp.compute_3D_ray(
+        mesh, origin, tangent, integral_pairs, 10, 1e-6)
+
+    if status > 0:
+        # Create structures needed for closest point projections
+        boundary_cells = dolfinx.mesh.compute_incident_entities(mesh, facets, tdim - 1, tdim)
+        bb_tree = dolfinx.geometry.BoundingBoxTree(mesh, tdim, boundary_cells)
+        midpoint_tree = dolfinx.cpp.geometry.create_midpoint_tree(mesh, tdim, boundary_cells)
+
+        # Find closest cell using closest point projection
+        closest_cell = dolfinx.geometry.compute_closest_entity(
+            bb_tree, midpoint_tree, mesh, np.reshape(origin, (1, 3)))[0]
+        assert integral_pairs[cell_idx][0] == closest_cell
+
+        # Compute actual distance between cell and point using GJK
+        cell_dofs = mesh.geometry.dofmap.links(closest_cell)
+        cell_geometry = np.empty((len(cell_dofs), 3), dtype=np.float64)
+        for i, dof in enumerate(cell_dofs):
+            cell_geometry[i, :] = mesh.geometry.x[dof, :]
+        distance = dolfinx.geometry.compute_distance_gjk(cell_geometry, origin)
+        assert np.allclose(points[0], origin + distance)
+
+
+@pytest.mark.parametrize("cell_type", [dolfinx.mesh.CellType.hexahedron, dolfinx.mesh.CellType.tetrahedron])
+def test_raytracing_corner(cell_type):
+    origin = [1.5, 1.5, 1.5]
+    tangent = [[1 / np.sqrt(2), 0, -1 / np.sqrt(2)], [-1 / np.sqrt(6), 2 / np.sqrt(6), -1 / np.sqrt(6)]]
+
+    mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 13, 11, 12, cell_type)
+    tdim = mesh.topology.dim
+    facets = dolfinx.mesh.locate_entities_boundary(mesh, tdim - 1, lambda x: np.isclose(x[2], 1))
+
+    integral_pairs = dolfinx_contact.cpp.compute_active_entities(mesh, facets, dolfinx.fem.IntegralType.exterior_facet)
+    status, cell_idx, points = dolfinx_contact.cpp.compute_3D_ray(
+        mesh, origin, tangent, integral_pairs, 10, 1e-6)
+    if status > 0:
+        # Create structures needed for closest point projections
+        boundary_cells = dolfinx.mesh.compute_incident_entities(mesh, facets, tdim - 1, tdim)
+        bb_tree = dolfinx.geometry.BoundingBoxTree(mesh, tdim, boundary_cells)
+        midpoint_tree = dolfinx.cpp.geometry.create_midpoint_tree(mesh, tdim, boundary_cells)
+
+        # Find closest cell using closest point projection
+        closest_cell = dolfinx.geometry.compute_closest_entity(
+            bb_tree, midpoint_tree, mesh, np.reshape(origin, (1, 3)))[0]
+
+        # Compute actual distance between cell and point using GJK
+        cell_dofs = mesh.geometry.dofmap.links(closest_cell)
+        cell_geometry = np.empty((len(cell_dofs), 3), dtype=np.float64)
+        for i, dof in enumerate(cell_dofs):
+            cell_geometry[i, :] = mesh.geometry.x[dof, :]
+        distance = dolfinx.geometry.compute_distance_gjk(cell_geometry, origin)
+        assert np.allclose(points[0], origin + distance)


### PR DESCRIPTION
Implements raytracing for 3D cells.

MWE:
```python
import dolfinx_contact
from mpi4py import MPI
import dolfinx
import numpy as np

mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 15, 15, 15, dolfinx.mesh.CellType.tetrahedron)
facets = dolfinx.mesh.locate_entities_boundary(mesh, mesh.topology.dim - 1, lambda x: np.isclose(x[2], 0))
integral_pairs = dolfinx_contact.cpp.compute_active_entities(mesh, facets, dolfinx.fem.IntegralType.exterior_facet)

status, cell_idx, points = dolfinx_contact.cpp.compute_3D_ray(
    mesh, [0.5, 0.3, -1], [[1, 0, 0], [0, 1, 0]], integral_pairs, 10, 1e-6)
print(
    f"Converged: {status} Entity: {integral_pairs[cell_idx]} Coordinate {points[0]} Reference Coordinate: {points[1]}")
```
If no cell is found that the ray goes through, a negative status is returned