### PR TITLE
Make sonarcloud properties indepenent of fork.

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -107,4 +107,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          sonar-scanner --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner --Dsonar.projectKey=$${{ secrets.SONAR_PROJECT }} --Dsonar.organization=$${ secrets.SONAR_ORGANIZATION }} -define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_PROJECT: $${{ secrets.SONAR_PROJECT }}
+          SONAR_PROJECT: ${{ secrets.SONAR_PROJECT }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
         run: |
           sonar-scanner --define sonar.projectKey=$SONAR_PROJECT --define sonar.organization=$SONAR_ORGANIZATION --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -107,4 +107,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          sonar-scanner --Dsonar.projectKey=$${{ secrets.SONAR_PROJECT }} --Dsonar.organization=$${ secrets.SONAR_ORGANIZATION }} -define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner --define sonar.projectKey=$${{ secrets.SONAR_PROJECT }} --define sonar.organization=${{ secrets.SONAR_ORGANIZATION }} --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -106,5 +106,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT: $${{ secrets.SONAR_PROJECT }}
+          SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
         run: |
-          sonar-scanner --define sonar.projectKey=$${{ secrets.SONAR_PROJECT }} --define sonar.organization=${{ secrets.SONAR_ORGANIZATION }} --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner --define sonar.projectKey=$SONAR_PROJECT --define sonar.organization=$SONAR_ORGANIZATION --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,3 @@
-sonar.projectKey=SarahRo_asimov-contact
-sonar.organization=srsonar
-
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=dolfinx_contact
 sonar.projectVersion=0.4.0


### PR DESCRIPTION
Instead of having the `projectKey` and `organization` hardcoded in `sonar-project.properties` they should be set as repository secrets, such that it could work for both our forks without having to change back and forth in the actual code.