### PR TITLE
Flatten integration entities in C++.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ core
 *.png
 **/CMakeFiles
 CMakeCache.txt
+*.txt
+*.cache

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 find_package(DOLFINX 0.4.2.0 REQUIRED)
 find_package(Basix 0.4.2.0 REQUIRED)
 find_package(xtensor REQUIRED)
-find_package(DOLFINX_CUAS 0.4.0 REQUIRED)
+find_package(DOLFINX_CUAS 0.4.1 REQUIRED)
 
 feature_summary(WHAT ALL)
 

--- a/cpp/Contact.cpp
+++ b/cpp/Contact.cpp
@@ -8,7 +8,6 @@
 #include "error_handling.h"
 #include "utils.h"
 #include <dolfinx/common/log.h>
-#include <dolfinx_cuas/utils.hpp>
 using namespace dolfinx_contact;
 
 namespace
@@ -87,15 +86,8 @@ dolfinx_contact::Contact::Contact(
     {
       std::vector<std::int32_t> facets = marker->find(links[i]);
       int index = surfaces->offsets()[s] + int(i);
-      std::variant<
-          std::vector<std::int32_t>, std::vector<std::pair<std::int32_t, int>>,
-          std::vector<std::tuple<std::int32_t, int, std::int32_t, int>>>
-          pairs = dolfinx_cuas::compute_active_entities(
-              mesh, facets, dolfinx::fem::IntegralType::exterior_facet);
-
-      _cell_facet_pairs[index]
-          = std::get<std::vector<std::pair<std::int32_t, int>>>(pairs);
-
+      _cell_facet_pairs[index] = dolfinx_contact::compute_active_entities(
+          mesh, facets, dolfinx::fem::IntegralType::exterior_facet);
       _submeshes[index]
           = dolfinx_contact::SubMesh(mesh, _cell_facet_pairs[index]);
     }
@@ -151,13 +143,13 @@ Mat dolfinx_contact::Contact::create_petsc_matrix(
         = _submeshes[contact_pair[1]].facet_map();
     const std::vector<std::int32_t>& parent_cells
         = _submeshes[contact_pair[1]].parent_cells();
-    for (int i = 0; i < (int)_cell_facet_pairs[contact_pair[0]].size(); i++)
+    for (int i = 0; i < (int)_cell_facet_pairs[contact_pair[0]].size(); i += 2)
     {
-      std::int32_t cell = _cell_facet_pairs[contact_pair[0]][i].first;
+      std::int32_t cell = _cell_facet_pairs[contact_pair[0]][i];
       tcb::span<const int> cell_dofs = dofmap->cell_dofs(cell);
 
       linked_dofs.clear();
-      for (auto link : _facet_maps[k]->links(i))
+      for (auto link : _facet_maps[k]->links(i / 2))
       {
         const int linked_sub_cell = facet_map->links(link)[0];
         const std::int32_t linked_cell = parent_cells[linked_sub_cell];
@@ -185,12 +177,10 @@ void dolfinx_contact::Contact::create_distance_map(int pair)
 {
   // Get quadrature mesh info
   int puppet_mt = _contact_pairs[pair][0];
-  const std::vector<std::pair<std::int32_t, int>>& puppet_facets
-      = _cell_facet_pairs[puppet_mt];
+  const std::vector<std::int32_t>& puppet_facets = _cell_facet_pairs[puppet_mt];
   std::shared_ptr<const dolfinx::mesh::Mesh> puppet_mesh
       = _submeshes[puppet_mt].mesh();
-  std::vector<std::pair<std::int32_t, int>> quadrature_facets(
-      puppet_facets.size());
+  std::vector<std::int32_t> quadrature_facets(puppet_facets.size());
   {
     const int tdim = puppet_mesh->topology().dim();
     std::shared_ptr<const dolfinx::graph::AdjacencyList<int>> c_to_f
@@ -199,19 +189,18 @@ void dolfinx_contact::Contact::create_distance_map(int pair)
     std::shared_ptr<const dolfinx::graph::AdjacencyList<int>> cell_map
         = _submeshes[puppet_mt].cell_map();
 
-    for (std::size_t i = 0; i < puppet_facets.size(); ++i)
+    for (std::size_t i = 0; i < puppet_facets.size(); i += 2)
     {
-      auto [f_cell, facet] = puppet_facets[i];
-      quadrature_facets[i] = {cell_map->links(f_cell)[0], facet};
+      auto sub_cells = cell_map->links(puppet_facets[i]);
+      assert(!sub_cells.empty());
+      quadrature_facets[i] = sub_cells.front();
+      quadrature_facets[i + 1] = puppet_facets[i + 1];
     }
   }
-
-  // Get candidate mesh information
   int candidate_mt = _contact_pairs[pair][1];
-  const std::vector<std::pair<std::int32_t, int>>& candidate_facets
+  const std::vector<std::int32_t>& candidate_facets
       = _cell_facet_pairs[candidate_mt];
-  std::vector<std::pair<std::int32_t, int>> submesh_facets(
-      candidate_facets.size());
+  std::vector<std::int32_t> submesh_facets(candidate_facets.size());
   std::shared_ptr<const dolfinx::mesh::Mesh> candidate_mesh
       = _submeshes[candidate_mt].mesh();
   {
@@ -222,10 +211,12 @@ void dolfinx_contact::Contact::create_distance_map(int pair)
     std::shared_ptr<const dolfinx::graph::AdjacencyList<int>> cell_map
         = _submeshes[candidate_mt].cell_map();
 
-    for (std::size_t i = 0; i < candidate_facets.size(); ++i)
+    for (std::size_t i = 0; i < candidate_facets.size(); i += 2)
     {
-      auto [f_cell, facet] = candidate_facets[i];
-      submesh_facets[i] = {cell_map->links(f_cell)[0], facet};
+      auto submesh_cell = cell_map->links(candidate_facets[i]);
+      assert(!submesh_cell.empty());
+      submesh_facets[i] = submesh_cell.front();
+      submesh_facets[i + 1] = candidate_facets[i + 1];
     }
   }
 
@@ -287,7 +278,7 @@ dolfinx_contact::Contact::pack_ny(int pair,
   const std::vector<xt::xtensor<double, 2>>& qp_phys
       = _qp_phys[contact_pair[0]];
 
-  const std::size_t num_facets = _cell_facet_pairs[contact_pair[0]].size();
+  const std::size_t num_facets = _cell_facet_pairs[contact_pair[0]].size() / 2;
   const std::size_t num_q_points
       = _quadrature_rule->offset()[1] - _quadrature_rule->offset()[0];
 
@@ -388,7 +379,7 @@ void dolfinx_contact::Contact::assemble_matrix(
   }
 
   const std::array<int, 2>& contact_pair = _contact_pairs[pair];
-  const std::vector<std::pair<std::int32_t, int>>& active_facets
+  const std::vector<std::int32_t>& active_facets
       = _cell_facet_pairs[contact_pair[0]];
   std::shared_ptr<const dolfinx::graph::AdjacencyList<int>> map
       = _facet_maps[pair];
@@ -402,11 +393,11 @@ void dolfinx_contact::Contact::assemble_matrix(
       3 * max_links + 1,
       std::vector<PetscScalar>(bs * ndofs_cell * bs * ndofs_cell));
   std::vector<std::int32_t> linked_cells;
-  for (std::size_t i = 0; i < active_facets.size(); i++)
+  for (std::size_t i = 0; i < active_facets.size(); i += 2)
   {
-    [[maybe_unused]] auto [cell, local_index] = active_facets[i];
     // Get cell coordinates/geometry
-    const tcb::span<const int> x_dofs = x_dofmap.links(cell);
+    assert(active_facets[i] < x_dofmap.num_nodes());
+    const tcb::span<const int> x_dofs = x_dofmap.links(active_facets[i]);
     for (std::size_t j = 0; j < x_dofs.size(); ++j)
     {
       std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), gdim,
@@ -416,7 +407,7 @@ void dolfinx_contact::Contact::assemble_matrix(
     if (max_links > 0)
     {
       // Compute the unique set of cells linked to the current facet
-      compute_linked_cells(linked_cells, map->links((int)i), facet_map,
+      compute_linked_cells(linked_cells, map->links((int)i / 2), facet_map,
                            parent_cells);
     }
     // Fill initial local element matrices with zeros prior to assembly
@@ -429,18 +420,18 @@ void dolfinx_contact::Contact::assemble_matrix(
       std::fill(Aes[3 * j + 3].begin(), Aes[3 * j + 3].end(), 0);
     }
 
-    kernel(Aes, coeffs.data() + i * cstride, constants.data(),
-           coordinate_dofs.data(), local_index, num_linked_cells);
+    kernel(Aes, coeffs.data() + i / 2 * cstride, constants.data(),
+           coordinate_dofs.data(), active_facets[i + 1], num_linked_cells);
 
     // FIXME: We would have to handle possible Dirichlet conditions here, if we
     // think that we can have a case with contact and Dirichlet
-    const tcb::span<const int> dmap_cell = dofmap->cell_dofs(cell);
+    auto dmap_cell = dofmap->cell_dofs(active_facets[i]);
     mat_set(dmap_cell, dmap_cell, Aes[0]);
 
     for (std::size_t j = 0; j < num_linked_cells; j++)
     {
-      const tcb::span<const int> dmap_linked
-          = dofmap->cell_dofs(linked_cells[j]);
+      auto dmap_linked = dofmap->cell_dofs(linked_cells[j]);
+      assert(!dmap_linked.empty());
       mat_set(dmap_cell, dmap_linked, Aes[3 * j + 1]);
       mat_set(dmap_linked, dmap_cell, Aes[3 * j + 2]);
       mat_set(dmap_linked, dmap_linked, Aes[3 * j + 3]);
@@ -484,7 +475,7 @@ void dolfinx_contact::Contact::assemble_vector(
   // Select which side of the contact interface to loop from and get the
   // correct map
   const std::array<int, 2>& contact_pair = _contact_pairs[pair];
-  const std::vector<std::pair<std::int32_t, int>>& active_facets
+  const std::vector<std::int32_t>& active_facets
       = _cell_facet_pairs[contact_pair[0]];
   const dolfinx_contact::SubMesh& submesh = _submeshes[contact_pair[1]];
   std::shared_ptr<const dolfinx::graph::AdjacencyList<int>> map
@@ -506,12 +497,11 @@ void dolfinx_contact::Contact::assemble_vector(
 
   // Tempoary array to hold cell links
   std::vector<std::int32_t> linked_cells;
-  for (std::size_t i = 0; i < active_facets.size(); i++)
+  for (std::size_t i = 0; i < active_facets.size(); i += 2)
   {
-    [[maybe_unused]] auto [cell, local_index] = active_facets[i];
 
     // Get cell coordinates/geometry
-    const tcb::span<const int> x_dofs = x_dofmap.links(cell);
+    const tcb::span<const int> x_dofs = x_dofmap.links(active_facets[i]);
     for (std::size_t j = 0; j < x_dofs.size(); ++j)
     {
       std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), gdim,
@@ -521,7 +511,7 @@ void dolfinx_contact::Contact::assemble_vector(
     // Compute the unique set of cells linked to the current facet
     if (max_links > 0)
     {
-      compute_linked_cells(linked_cells, map->links((int)i), facet_map,
+      compute_linked_cells(linked_cells, map->links((int)i / 2), facet_map,
                            parent_cells);
     }
 
@@ -530,11 +520,11 @@ void dolfinx_contact::Contact::assemble_vector(
     std::fill(bes[0].begin(), bes[0].end(), 0);
     for (std::size_t j = 0; j < num_linked_cells; j++)
       std::fill(bes[j + 1].begin(), bes[j + 1].end(), 0);
-    kernel(bes, coeffs.data() + i * cstride, constants.data(),
-           coordinate_dofs.data(), local_index, num_linked_cells);
+    kernel(bes, coeffs.data() + i / 2 * cstride, constants.data(),
+           coordinate_dofs.data(), active_facets[i + 1], num_linked_cells);
 
     // Add element vector to global vector
-    const tcb::span<const int> dofs_cell = dofmap->cell_dofs(cell);
+    const tcb::span<const int> dofs_cell = dofmap->cell_dofs(active_facets[i]);
     for (std::size_t j = 0; j < ndofs_cell; ++j)
       for (int k = 0; k < bs; ++k)
         b[bs * dofs_cell[j] + k] += bes[0][bs * j + k];

--- a/cpp/Contact.cpp
+++ b/cpp/Contact.cpp
@@ -332,9 +332,8 @@ dolfinx_contact::Contact::pack_ny(int pair,
           J, K, point, coordinate_dofs, linked_pair[1], cmap,
           reference_normals);
       // Copy normal into c
-      const std::size_t offset = i * cstride + q * gdim;
-      for (int l = 0; l < gdim; ++l)
-        normals[offset + l] = normal[l];
+      std::copy_n(normal.begin(), gdim,
+                  std::next(normals.begin(), i * cstride + q * gdim));
     }
   }
   return {std::move(normals), cstride};

--- a/cpp/RayTracing.cpp
+++ b/cpp/RayTracing.cpp
@@ -8,11 +8,11 @@
 #include "RayTracing.h"
 //------------------------------------------------------------------------------------------------
 std::tuple<int, std::int32_t, xt::xtensor<double, 1>, xt::xtensor<double, 1>>
-dolfinx_contact::raytracing(
-    const dolfinx::mesh::Mesh& mesh, const xt::xtensor<double, 1>& point,
-    const xt::xtensor<double, 1>& normal,
-    const std::vector<std::pair<std::int32_t, int>>& cells, const int max_iter,
-    const double tol)
+dolfinx_contact::raytracing(const dolfinx::mesh::Mesh& mesh,
+                            const xt::xtensor<double, 1>& point,
+                            const xt::xtensor<double, 1>& normal,
+                            xtl::span<const std::int32_t> cells,
+                            const int max_iter, const double tol)
 {
   const int tdim = mesh.topology().dim();
   const int gdim = mesh.geometry().dim();

--- a/cpp/SubMesh.cpp
+++ b/cpp/SubMesh.cpp
@@ -94,7 +94,7 @@ dolfinx_contact::SubMesh::SubMesh(
       // cell facet index the same for both meshes: use c_to_f to
       // get submesh facet index
       auto facets = c_to_f->links(sub_cells.front());
-      assert(cell_facet_pairs[i + 1] < facets.size());
+      assert((std::size_t)cell_facet_pairs[i + 1] < facets.size());
       std::int32_t submesh_facet = facets[cell_facet_pairs[i + 1]];
       marked_facets[submesh_facet] = 2;
     }

--- a/cpp/SubMesh.cpp
+++ b/cpp/SubMesh.cpp
@@ -195,14 +195,13 @@ void dolfinx_contact::SubMesh::update_geometry(
       = u.function_space()->mesh();
   tcb::span<double> sub_geometry = _mesh->geometry().x();
   tcb::span<const double> parent_geometry = parent_mesh->geometry().x();
-  std::size_t gdim = _mesh->geometry().dim();
   std::size_t num_x_dofs = sub_geometry.size() / 3;
   for (std::size_t i = 0; i < num_x_dofs; ++i)
-    for (std::size_t j = 0; j < gdim; ++j)
-    {
-      std::size_t parent_index = _submesh_to_mesh_x_dof_map[i];
-      sub_geometry[3 * i + j] = parent_geometry[3 * parent_index + j];
-    }
+  {
+    dolfinx::common::impl::copy_N<3>(
+        std::next(parent_geometry.begin(), 3 * _submesh_to_mesh_x_dof_map[i]),
+        std::next(sub_geometry.begin(), 3 * i));
+  }
   // use u to update geometry
   std::shared_ptr<const dolfinx::fem::FunctionSpace> V_parent
       = u.function_space();

--- a/cpp/SubMesh.cpp
+++ b/cpp/SubMesh.cpp
@@ -114,7 +114,7 @@ dolfinx_contact::SubMesh::SubMesh(
       // cell facet index the same for both meshes: use c_to_f to
       // get submesh facet index
       auto facets = c_to_f->links(sub_cells.front());
-      assert(cell_facet_pairs[i + 1] < facets.size());
+      assert((std::size_t)cell_facet_pairs[i + 1] < facets.size());
       std::int32_t submesh_facet = facets[cell_facet_pairs[i + 1]];
       data[offsets[submesh_facet]] = sub_cells.front();
       data[offsets[submesh_facet] + 1] = cell_facet_pairs[i + 1];

--- a/cpp/SubMesh.h
+++ b/cpp/SubMesh.h
@@ -29,9 +29,9 @@ public:
   /// @param[in] mesh - the parent mesh
   /// @param[in] facets - vector of pairs (cell, facet) of exterior facets,
   /// where cell is the index of the cell local to the process and facet is
-  /// the facet index within the cell
+  /// the facet index within the cell. The data is flattened row-major.
   SubMesh(std::shared_ptr<const dolfinx::mesh::Mesh> mesh,
-          std::vector<std::pair<std::int32_t, int>>& facets);
+          xtl::span<const std::int32_t> facets);
 
   // Return mesh
   std::shared_ptr<const dolfinx::mesh::Mesh> mesh() const { return _mesh; }

--- a/cpp/coefficients.cpp
+++ b/cpp/coefficients.cpp
@@ -174,12 +174,12 @@ dolfinx_contact::pack_coefficient_quadrature(
       // Get cell geometry (coordinate dofs)
       auto x_dofs = x_dofmap.links(cell);
       assert(x_dofs.size() == num_dofs_g);
-      for (std::size_t k = 0; k < num_dofs_g; ++k)
+      for (std::size_t j = 0; j < num_dofs_g; ++j)
       {
-        const int pos = 3 * x_dofs[k];
-        for (int j = 0; j < gdim; ++j)
-          coordinate_dofs(k, j) = x_g[pos + j];
+        std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), gdim,
+                    std::next(coordinate_dofs.begin(), j * gdim));
       }
+
       if (cmap.is_affine())
       {
         std::fill(J.begin(), J.end(), 0);

--- a/cpp/coefficients.cpp
+++ b/cpp/coefficients.cpp
@@ -17,10 +17,8 @@ using namespace dolfinx_contact;
 std::pair<std::vector<PetscScalar>, int>
 dolfinx_contact::pack_coefficient_quadrature(
     std::shared_ptr<const dolfinx::fem::Function<PetscScalar>> coeff,
-    const int q_degree,
-    std::variant<tcb::span<const std::int32_t>,
-                 tcb::span<const std::pair<std::int32_t, int>>>
-        active_entities)
+    const int q_degree, tcb::span<const std::int32_t> active_entities,
+    dolfinx::fem::IntegralType integral)
 {
   // Get mesh
   std::shared_ptr<const dolfinx::mesh::Mesh> mesh
@@ -34,27 +32,17 @@ dolfinx_contact::pack_coefficient_quadrature(
 
   // Get what entity type we are integrating over
   int entity_dim;
-  std::visit(
-      [&entity_dim, tdim](auto& entities)
-      {
-        using U = std::decay_t<decltype(entities)>;
-        if constexpr (std::is_same_v<U, tcb::span<const std::int32_t>>)
-          entity_dim = tdim;
-        else if constexpr (std::is_same_v<
-                               U,
-                               tcb::span<const std::pair<std::int32_t, int>>>)
-        {
-          entity_dim = tdim - 1;
-        }
-        else
-        {
-          throw std::invalid_argument(
-              "Could not pack coefficients. Input entity "
-              "type is not supported.");
-        }
-      },
-      active_entities);
-
+  switch (integral)
+  {
+  case dolfinx::fem::IntegralType::cell:
+    entity_dim = tdim;
+    break;
+  case dolfinx::fem::IntegralType::exterior_facet:
+    entity_dim = tdim - 1;
+    break;
+  default:
+    throw std::invalid_argument("Unsupported integral type.");
+  }
   // Create quadrature rule
   QuadratureRule q_rule(cell_type, q_degree, entity_dim);
 
@@ -77,40 +65,19 @@ dolfinx_contact::pack_coefficient_quadrature(
   xt::xtensor<double, 4> reference_basis_values(tab_shape);
   element->tabulate(reference_basis_values, q_points, 0);
 
-  std::function<std::pair<std::int32_t, int>(std::size_t)> get_cell_info;
+  std::function<std::array<std::int32_t, 2>(std::size_t)> get_cell_info;
   std::size_t num_active_entities;
-  // TODO see if this can be simplified with templating
-  std::visit(
-      [&num_active_entities, &get_cell_info](auto& entities)
-      {
-        using U = std::decay_t<decltype(entities)>;
-        if constexpr (std::is_same_v<U, tcb::span<const std::int32_t>>)
-        {
-          num_active_entities = entities.size();
-          // Iterate over coefficients
-          get_cell_info = [&entities](auto i)
-          {
-            std::pair<std::int32_t, int> pair(entities[i], 0);
-            return pair;
-          };
-        }
-        else if constexpr (std::is_same_v<
-                               U,
-                               tcb::span<const std::pair<std::int32_t, int>>>)
-        {
-          num_active_entities = entities.size();
-          // Create lambda function fetching cell index from exterior facet
-          // entity
-          get_cell_info = [&entities](auto i) { return entities[i]; };
-        }
-        else
-        {
-          throw std::invalid_argument(
-              "Could not pack coefficient. Input entity "
-              "type is not supported.");
-        }
-      },
-      active_entities);
+  switch (integral)
+  {
+  case dolfinx::fem::IntegralType::cell:
+    num_active_entities = active_entities.size();
+    break;
+  case dolfinx::fem::IntegralType::exterior_facet:
+    num_active_entities = active_entities.size() / 2;
+    break;
+  default:
+    throw std::invalid_argument("Unsupported integral type.");
+  }
 
   // Create output array
   const std::vector<std::int32_t>& q_offsets = q_rule.offset();
@@ -187,7 +154,22 @@ dolfinx_contact::pack_coefficient_quadrature(
 
     for (std::size_t i = 0; i < num_active_entities; i++)
     {
-      auto [cell, entity_index] = get_cell_info(i);
+      // Get local cell info
+      std::int32_t cell;
+      std::int32_t entity_index;
+      switch (integral)
+      {
+      case dolfinx::fem::IntegralType::cell:
+        cell = active_entities[i];
+        entity_index = 0;
+        break;
+      case dolfinx::fem::IntegralType::exterior_facet:
+        cell = active_entities[2 * i];
+        entity_index = active_entities[2 * i + 1];
+        break;
+      default:
+        throw std::invalid_argument("Unsupported integral type.");
+      }
 
       // Get cell geometry (coordinate dofs)
       auto x_dofs = x_dofmap.links(cell);
@@ -274,7 +256,23 @@ dolfinx_contact::pack_coefficient_quadrature(
     // Loop over all entities
     for (std::size_t i = 0; i < num_active_entities; i++)
     {
-      auto [cell, entity_index] = get_cell_info(i);
+      // Get local cell info
+      std::int32_t cell;
+      std::int32_t entity_index;
+      switch (integral)
+      {
+      case dolfinx::fem::IntegralType::cell:
+        cell = active_entities[i];
+        entity_index = 0;
+        break;
+      case dolfinx::fem::IntegralType::exterior_facet:
+        cell = active_entities[2 * i];
+        entity_index = active_entities[2 * i + 1];
+        break;
+      default:
+        throw std::invalid_argument("Unsupported integral type.");
+      }
+
       auto dofs = dofmap->cell_dofs(cell);
       const std::int32_t q_offset = q_offsets[entity_index];
 
@@ -309,7 +307,7 @@ dolfinx_contact::pack_coefficient_quadrature(
 //-----------------------------------------------------------------------------
 std::vector<PetscScalar> dolfinx_contact::pack_circumradius(
     const dolfinx::mesh::Mesh& mesh,
-    const tcb::span<const std::pair<std::int32_t, int>>& active_facets)
+    const tcb::span<const std::int32_t>& active_facets)
 {
   const dolfinx::mesh::Geometry& geometry = mesh.geometry();
   const dolfinx::mesh::Topology& topology = mesh.topology();
@@ -339,7 +337,7 @@ std::vector<PetscScalar> dolfinx_contact::pack_circumradius(
 
   // Prepare output variables
   std::vector<PetscScalar> circumradius;
-  circumradius.reserve(active_facets.size());
+  circumradius.reserve(active_facets.size() / 2);
 
   // Get geometry data
   const dolfinx::graph::AdjacencyList<std::int32_t>& x_dofmap
@@ -356,15 +354,16 @@ std::vector<PetscScalar> dolfinx_contact::pack_circumradius(
       = xt::zeros<double>({num_dofs_g, (std::size_t)gdim});
   xt::xtensor<double, 2> dphi_q({(std::size_t)tdim, num_dofs_g});
   assert(num_dofs_g == tab_shape[2]);
-  for (auto [cell, local_index] : active_facets)
+  for (std::size_t i = 0; i < active_facets.size(); i += 2)
   {
+    std::int32_t cell = active_facets[i];
+    std::int32_t local_index = active_facets[i + 1];
     // Get cell geometry (coordinate dofs)
     auto x_dofs = x_dofmap.links(cell);
-    for (std::size_t i = 0; i < num_dofs_g; ++i)
+    for (std::size_t j = 0; j < x_dofs.size(); ++j)
     {
-      const int pos = 3 * x_dofs[i];
-      for (int j = 0; j < gdim; ++j)
-        coordinate_dofs(i, j) = x_g[pos + j];
+      std::copy_n(std::next(x_g.begin(), 3 * x_dofs[j]), gdim,
+                  std::next(coordinate_dofs.begin(), j * gdim));
     }
 
     // Compute determinant of Jacobian which is used to compute the
@@ -378,6 +377,6 @@ std::vector<PetscScalar> dolfinx_contact::pack_circumradius(
         = dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J);
     circumradius.push_back(compute_circumradius(mesh, detJ, coordinate_dofs));
   }
-  assert(circumradius.size() == active_facets.size());
+  assert(circumradius.size() == active_facets.size() / 2);
   return circumradius;
 }

--- a/cpp/coefficients.h
+++ b/cpp/coefficients.h
@@ -30,15 +30,13 @@ namespace dolfinx_contact
 /// @param[in] coeff The coefficient to pack
 /// @param[in] q_degree The quadrature degree
 /// @param[in] integral The integral type (cell or exterior facet)
-/// @param[in] active_entities List of active entities (cells or exterior
-/// facets)
+/// @param[in] active_entities List of active entities.
+/// @param[in] integral The integral type (cells or exterior facet)
 /// @returns c The packed coefficients and the number of coeffs per entity
 std::pair<std::vector<PetscScalar>, int> pack_coefficient_quadrature(
     std::shared_ptr<const dolfinx::fem::Function<PetscScalar>> coeff,
-    const int q_degree,
-    std::variant<tcb::span<const std::int32_t>,
-                 tcb::span<const std::pair<std::int32_t, int>>>
-        active_entities);
+    const int q_degree, tcb::span<const std::int32_t> active_entities,
+    dolfinx::fem::IntegralType integral);
 
 /// Prepare circumradii of triangle/tetrahedron for assembly with custom
 /// kernels by packing them as an array, where the ith entry of the output
@@ -47,7 +45,7 @@ std::pair<std::vector<PetscScalar>, int> pack_coefficient_quadrature(
 /// @param[in] active_facets List of (cell, local_facet_index) tuples
 /// @returns[out] The packed coefficients
 /// @note Circumradius is constant and therefore the cstride is 1
-std::vector<PetscScalar> pack_circumradius(
-    const dolfinx::mesh::Mesh& mesh,
-    const tcb::span<const std::pair<std::int32_t, int>>& active_facets);
+std::vector<PetscScalar>
+pack_circumradius(const dolfinx::mesh::Mesh& mesh,
+                  const tcb::span<const std::int32_t>& active_facets);
 } // namespace dolfinx_contact

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -570,7 +570,7 @@ std::vector<std::int32_t> dolfinx_contact::compute_active_entities(
     assert(f_to_c);
     auto c_to_f = topology.connectivity(tdim, tdim - 1);
     assert(c_to_f);
-    for (std::int32_t f = 0; f < entities.size(); f++)
+    for (std::size_t f = 0; f < entities.size(); f++)
     {
       assert(f_to_c->num_links(entities[f]) == 1);
       const std::int32_t cell = f_to_c->links(entities[f])[0];
@@ -846,7 +846,7 @@ dolfinx_contact::compute_distance_map(
     {
       auto local_facets = c_to_f->links(candidate_facets[i]);
       assert(!local_facets.empty());
-      assert(candidate_facets[i + 1] < local_facets.size());
+      assert((std::size_t)candidate_facets[i + 1] < local_facets.size());
       facets[i / 2] = local_facets[candidate_facets[i + 1]];
     }
     // Compute closest entity for each quadrature point

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -580,7 +580,8 @@ std::vector<std::int32_t> dolfinx_contact::compute_active_entities(
           = std::find(cell_facets.begin(), cell_facets.end(), entities[f]);
       assert(facet_it != cell_facets.end());
       active_entities[2 * f] = cell;
-      active_entities[2 * f + 1] = std::distance(cell_facets.begin(), facet_it);
+      active_entities[2 * f + 1]
+          = (std::int32_t)std::distance(cell_facets.begin(), facet_it);
     }
     return active_entities;
   }
@@ -607,7 +608,7 @@ std::vector<std::int32_t> dolfinx_contact::compute_active_entities(
         assert(facet_it != cell_facets.end());
         active_entities[4 * f + 2 * i] = cells[i];
         active_entities[4 * f + 2 * i + 1]
-            = std::distance(cell_facets.begin(), facet_it);
+            = (std::int32_t)std::distance(cell_facets.begin(), facet_it);
       }
     }
     return active_entities;

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -596,7 +596,7 @@ std::vector<std::int32_t> dolfinx_contact::compute_active_entities(
     auto c_to_f = topology.connectivity(tdim, tdim - 1);
     if (!c_to_f)
       throw std::runtime_error("Cell to facet connecitivty missing");
-    for (std::int32_t f = 0; f < entities.size(); f++)
+    for (std::size_t f = 0; f < entities.size(); f++)
     {
       assert(f_to_c->num_links(entities[f]) == 2);
       auto cells = f_to_c->links(entities[f]);

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -185,15 +185,12 @@ get_update_normal(const dolfinx::fem::CoordinateElement& cmap);
 /// exterior facets, return a list of pairs (cell, local_facet_index), and if it
 /// is interior facets, return a list of tuples (cell_0, local_facet_index_0,
 /// cell_1, local_facet_index_1) for each entity.
-///
 /// @param[in] mesh The mesh
 /// @param[in] entities List of mesh entities
 /// @param[in] integral The type of integral
-std::variant<std::vector<std::int32_t>,
-             std::vector<std::pair<std::int32_t, int>>,
-             std::vector<std::tuple<std::int32_t, int, std::int32_t, int>>>
+std::vector<std::int32_t>
 compute_active_entities(std::shared_ptr<const dolfinx::mesh::Mesh> mesh,
-                        tcb::span<const std::int32_t> entities,
+                        xtl::span<const std::int32_t> entities,
                         dolfinx::fem::IntegralType integral);
 
 /// @brief Compute the geometry dof indices for a set of entities
@@ -203,8 +200,8 @@ compute_active_entities(std::shared_ptr<const dolfinx::mesh::Mesh> mesh,
 /// @param[in] mesh The mesh
 /// @param[in] dim The dimension of the entities
 /// @param[in] entities List of mesh entities
-/// @returns An adjacency list where the i-th link corresponds to the closure
-/// dofs of the i-th input entity
+/// @returns An adjacency list where the i-th link corresponds to the
+/// closure dofs of the i-th input entity
 dolfinx::graph::AdjacencyList<std::int32_t>
 entities_to_geometry_dofs(const mesh::Mesh& mesh, int dim,
                           const xtl::span<const std::int32_t>& entity_list);
@@ -230,25 +227,35 @@ std::vector<std::int32_t> find_candidate_surface_segment(
 /// reference facets compute physical points
 ///
 /// @param[in] mesh The mesh
-/// @param[in] facets The list of facets as (cell, local_facet)
+/// @param[in] facets The list of facets as (cell, local_facet). The data is
+/// flattened row-major
 /// @param[in] offsets for accessing the basis_values for local_facet
 /// @param[in] phi Basis functions evaluated at desired set of point osn
 /// reference facet
 /// @param[in, out] qp_phys vector to stor physical points per facet
-void compute_physical_points(
-    const dolfinx::mesh::Mesh& mesh,
-    const std::vector<std::pair<std::int32_t, int>>& facets,
-    const std::vector<int>& offsets, const xt::xtensor<double, 2>& phi,
-    std::vector<xt::xtensor<double, 2>>& qp_phys);
+void compute_physical_points(const dolfinx::mesh::Mesh& mesh,
+                             xtl::span<const std::int32_t> facets,
+                             const std::vector<int>& offsets,
+                             const xt::xtensor<double, 2>& phi,
+                             std::vector<xt::xtensor<double, 2>>& qp_phys);
 
-/// Compute the closest entity at every quadrature point on asubset of facets on
-/// one mesh, to a subset of facets on the other mesh.
-
-dolfinx::graph::AdjacencyList<std::int32_t> compute_distance_map(
-    const dolfinx::mesh::Mesh& quadrature_mesh,
-    const std::vector<std::pair<std::int32_t, int>>& quadrature_facets,
-    const dolfinx::mesh::Mesh& candidate_mesh,
-    const std::vector<std::pair<std::int32_t, int>>& candidate_facets,
-    const QuadratureRule& q_rule);
+/// Compute the closest entity at every quadrature point on a subset of facets
+/// on one mesh, to a subset of facets on the other mesh.
+/// @param[in] quadrature_mesh The mesh to compute quadrature points on
+/// @param[in] quadrature_facets The facets to compute quadrature points on,
+/// defined as (cell, local_facet_index). Flattened row-major.
+/// @param[in] candidate_mesh The mesh with the facets we want to compute the
+/// distance to
+/// @param[in] candidate_facets The facets on candidate_mesh,defined as (cell,
+/// local_facet_index). Flattened row-major.
+/// @returns An adjacency list for each input facet in quadrature facets, where
+/// the links indicate which facet on the other mesh is closest for each
+/// quadrature point.
+dolfinx::graph::AdjacencyList<std::int32_t>
+compute_distance_map(const dolfinx::mesh::Mesh& quadrature_mesh,
+                     xtl::span<const std::int32_t> quadrature_facets,
+                     const dolfinx::mesh::Mesh& candidate_mesh,
+                     xtl::span<const std::int32_t> candidate_facets,
+                     const QuadratureRule& q_rule);
 
 } // namespace dolfinx_contact

--- a/python/dolfinx_contact/meshing/contact_meshes.py
+++ b/python/dolfinx_contact/meshing/contact_meshes.py
@@ -14,7 +14,7 @@ __all__ = ["create_circle_plane_mesh", "create_circle_circle_mesh", "create_box_
            "create_cylinder_cylinder_mesh"]
 
 
-def create_circle_plane_mesh(filename: str, quads: bool = False, res=0.1):
+def create_circle_plane_mesh(filename: str, quads: bool = False, res=0.1, order: int = 1):
     """
     Create a circular mesh, with center at (0.5,0.5,0) with radius 3 and a box [0,1]x[0,0.1]
     """
@@ -72,13 +72,15 @@ def create_circle_plane_mesh(filename: str, quads: bool = False, res=0.1):
         gmsh.model.mesh.field.setAsBackgroundMesh(2)
 
         gmsh.model.mesh.generate(2)
+        gmsh.model.mesh.setOrder(order)
+
         # gmsh.option.setNumber("Mesh.SaveAll", 1)
         gmsh.write(filename)
     MPI.COMM_WORLD.Barrier()
     gmsh.finalize()
 
 
-def create_circle_circle_mesh(filename: str, quads: bool = False, res: float = 0.1):
+def create_circle_circle_mesh(filename: str, quads: bool = False, res: float = 0.1, order: int = 1):
     """
     Create two circular meshes, with radii 0.3 and 0.6 with centers (0.5,0.5) and (0.5, -0.5)
     """
@@ -136,15 +138,16 @@ def create_circle_circle_mesh(filename: str, quads: bool = False, res: float = 0
             gmsh.option.setNumber("Mesh.RecombineAll", 2)
             gmsh.option.setNumber("Mesh.SubdivisionAlgorithm", 1)
         gmsh.model.mesh.field.setAsBackgroundMesh(2)
-
         gmsh.model.mesh.generate(2)
+        gmsh.model.mesh.setOrder(order)
+
         # gmsh.option.setNumber("Mesh.SaveAll", 1)
         gmsh.write(filename)
     MPI.COMM_WORLD.Barrier()
     gmsh.finalize()
 
 
-def create_box_mesh_2D(filename: str, quads: bool = False, res=0.1):
+def create_box_mesh_2D(filename: str, quads: bool = False, res=0.1, order: int = 1):
     """
     Create two boxes, one slightly skewed
     """
@@ -194,11 +197,14 @@ def create_box_mesh_2D(filename: str, quads: bool = False, res=0.1):
         gmsh.model.addPhysicalGroup(2, [surface2], 2)
         bndry2 = gmsh.model.getBoundary([(2, surface2)], oriented=False)
         [gmsh.model.addPhysicalGroup(b[0], [b[1]]) for b in bndry2]
+
         if quads:
             gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 8)
             gmsh.option.setNumber("Mesh.RecombineAll", 2)
             gmsh.option.setNumber("Mesh.SubdivisionAlgorithm", 1)
         gmsh.model.mesh.generate(2)
+        gmsh.model.mesh.setOrder(order)
+
         # gmsh.option.setNumber("Mesh.SaveAll", 1)
         gmsh.write(filename)
     MPI.COMM_WORLD.Barrier()
@@ -206,7 +212,7 @@ def create_box_mesh_2D(filename: str, quads: bool = False, res=0.1):
     gmsh.finalize()
 
 
-def create_box_mesh_3D(filename: str, simplex: bool = True, res=0.1):
+def create_box_mesh_3D(filename: str, simplex: bool = True, res=0.1, order: int = 1):
     """
     Create two boxes lying directly over eachother with a gap in between"""
     L = 0.5
@@ -251,19 +257,19 @@ def create_box_mesh_3D(filename: str, simplex: bool = True, res=0.1):
         model.addPhysicalGroup(3, [volumes[1][1]])
         bndry2 = model.getBoundary([(3, volumes[1][1])], oriented=False)
         [model.addPhysicalGroup(b[0], [b[1]]) for b in bndry2]
-
         if not simplex:
             gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 2)
             gmsh.option.setNumber("Mesh.RecombineAll", 2)
             gmsh.option.setNumber("Mesh.SubdivisionAlgorithm", 1)
         model.mesh.generate(3)
+        model.mesh.setOrder(order)
         # gmsh.option.setNumber("Mesh.SaveAll", 1)
         gmsh.write(filename)
     MPI.COMM_WORLD.Barrier()
     gmsh.finalize()
 
 
-def create_sphere_plane_mesh(filename: str):
+def create_sphere_plane_mesh(filename: str, order: int = 1):
     """
     Create a 3D sphere with center (0,0,0), r=0.3
     with a box at [-0.3, 0.6] x [-0.3, 0.6] x [ -0.1, -0.5]
@@ -316,13 +322,15 @@ def create_sphere_plane_mesh(filename: str):
         gmsh.model.mesh.field.setAsBackgroundMesh(2)
 
         gmsh.model.mesh.generate(3)
+        gmsh.model.mesh.setOrder(order)
+
         # gmsh.option.setNumber("Mesh.SaveAll", 1)
         gmsh.write(filename)
     MPI.COMM_WORLD.Barrier()
     gmsh.finalize()
 
 
-def create_sphere_sphere_mesh(filename: str):
+def create_sphere_sphere_mesh(filename: str, order: int = 1):
     """
     Create a 3D mesh consisting of two spheres with radii 0.3 and 0.6 and
     centers (0.5,0.5,0.5) and (0.5,0.5,-0.5)
@@ -375,6 +383,8 @@ def create_sphere_sphere_mesh(filename: str):
         gmsh.model.mesh.field.setAsBackgroundMesh(2)
 
         gmsh.model.mesh.generate(3)
+        gmsh.model.mesh.setOrder(order)
+
         # gmsh.option.setNumber("Mesh.SaveAll", 1)
         gmsh.write(filename)
     MPI.COMM_WORLD.Barrier()

--- a/python/dolfinx_contact/unbiased/nitsche_unbiased.py
+++ b/python/dolfinx_contact/unbiased/nitsche_unbiased.py
@@ -36,7 +36,7 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_tags: list[MeshTags_int32],
                      nitsche_parameters: dict[str, np.float64],
                      quadrature_degree: int = 5, form_compiler_params: dict = None, jit_params: dict = None,
                      petsc_options: dict = None, newton_options: dict = None, initial_guess=None,
-                     outfile: str = None) -> Tuple[_fem.Function, int, int, float]:
+                     outfile: str = None, order: int = 1) -> Tuple[_fem.Function, int, int, float]:
     """
     Use custom kernel to compute the contact problem with two elastic bodies coming into contact.
 
@@ -93,6 +93,8 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_tags: list[MeshTags_int32],
         A functon containing an intial guess to use for the Newton-solver
     outfile
         File to append solver summary
+    order
+        The order of mesh and function space
     """
     form_compiler_params = {} if form_compiler_params is None else form_compiler_params
     jit_params = {} if jit_params is None else jit_params
@@ -131,9 +133,8 @@ def nitsche_unbiased(mesh: _mesh.Mesh, mesh_tags: list[MeshTags_int32],
     else:
         gamma: np.float64 = _gamma * E
     lifting = nitsche_parameters.get("lift_bc", False)
-
     # Functions space and FEM functions
-    V = _fem.VectorFunctionSpace(mesh, ("CG", 1))
+    V = _fem.VectorFunctionSpace(mesh, ("CG", order))
     u = _fem.Function(V)
     v = ufl.TestFunction(V)
     du = ufl.TrialFunction(V)


### PR DESCRIPTION
Integration entities are unrolled in Python to be 1D (cell integrals), 2D (Exterior facet), 3D (Interior facet).

Preparing code for higher order function spaces. Currently does not work due to a bug in higher order submeshes, see: https://github.com/FEniCS/dolfinx/pull/2233