### PR TITLE
Remove meshio and h5py dependency in mesh conversion from GMSH

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -45,13 +45,7 @@ jobs:
       CONTACT_CMAKE_CXX_FLAGS: "-Wall -Werror -g -pedantic -Ofast -march=native"
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install meshio/h5py
-        run: |
-          pip3 install mpi4py --no-cache-dir --upgrade
-          HDF5_MPI="ON" HDF5_DIR="/usr/local" pip3 install --no-cache-dir --no-binary=h5py h5py --upgrade
-          pip3 install meshio --no-cache-dir --upgrade
-
+      
       - name: Get Basix and install
         uses: actions/checkout@v2
         with:
@@ -121,6 +115,7 @@ jobs:
         run: |
           cd python/demos
           mkdir -p results
+          mkdir -p meshes
           python3 compare_custom_snes_one_sided.py
           python3 compare_nitsche_snes.py
           python3 demo_nitsche_rigid_surface_ufl.py
@@ -134,4 +129,5 @@ jobs:
       - name: Run tests
         run: |
           cd python/tests
+          mkdir -p meshes
           python3 -m pytest . -vs

--- a/python/demos/compare_custom_snes_one_sided.py
+++ b/python/demos/compare_custom_snes_one_sided.py
@@ -5,7 +5,7 @@
 # Compare our own Nitsche implementation using custom integration kernels with SNES
 
 import argparse
-
+import os
 import numpy as np
 import ufl
 from dolfinx.common import timing
@@ -80,15 +80,17 @@ if __name__ == "__main__":
     petsc_snes = {"ksp_type": "cg", "ksp_rtol": 1e-5, "pc_type": "jacobi"}
     # Load mesh and create identifier functions for the top (Displacement condition)
     # and the bottom (contact condition)
+    outdir = "meshes"
+    os.system(f"mkdir -p {outdir}")
     if threed:
         if cube:
             mesh = create_unit_cube(MPI.COMM_WORLD, 10, 10, 20)
         else:
-            fname = "sphere"
+            fname = f"{outdir}/sphere"
             create_sphere_mesh(filename=f"{fname}.msh")
-            convert_mesh(fname, fname, "tetra")
+            convert_mesh(fname, fname, gdim=3)
             with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-                mesh = xdmf.read_mesh(name="Grid")
+                mesh = xdmf.read_mesh()
 
         def top(x):
             return x[2] > 0.9
@@ -100,11 +102,11 @@ if __name__ == "__main__":
         if cube:
             mesh = create_unit_square(MPI.COMM_WORLD, 30, 30)
         else:
-            fname = "disk"
+            fname = f"{outdir}/disk"
             create_disk_mesh(filename=f"{fname}.msh")
-            convert_mesh(fname, fname, "triangle", prune_z=True)
+            convert_mesh(fname, fname, gdim=2)
             with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-                mesh = xdmf.read_mesh(name="Grid")
+                mesh = xdmf.read_mesh()
 
         def top(x):
             return x[1] > 0.5

--- a/python/demos/compare_nitsche_snes.py
+++ b/python/demos/compare_nitsche_snes.py
@@ -70,15 +70,16 @@ if __name__ == "__main__":
 
     # Load mesh and create identifier functions for the top (Displacement condition)
     # and the bottom (contact condition)
+    mesh_dir = "meshes"
     if threed:
         if cube:
             mesh = create_unit_cube(MPI.COMM_WORLD, 10, 10, 20)
         else:
-            fname = "sphere"
+            fname = f"{mesh_dir}/sphere"
             create_sphere_mesh(filename=f"{fname}.msh")
-            convert_mesh(fname, fname, "tetra")
+            convert_mesh(fname, fname, gdim=3)
             with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-                mesh = xdmf.read_mesh(name="Grid")
+                mesh = xdmf.read_mesh()
 
         def top(x):
             return x[2] > 0.9
@@ -90,11 +91,11 @@ if __name__ == "__main__":
         if cube:
             mesh = create_unit_square(MPI.COMM_WORLD, 30, 30)
         else:
-            fname = "disk"
+            fname = f"{mesh_dir}/disk"
             create_disk_mesh(filename=f"{fname}.msh")
-            convert_mesh(fname, fname, "triangle", prune_z=True)
+            convert_mesh(fname, fname, gdim=3)
             with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-                mesh = xdmf.read_mesh(name="Grid")
+                mesh = xdmf.read_mesh()
 
         def top(x):
             return x[1] > 0.5

--- a/python/demos/compare_nitsche_snes.py
+++ b/python/demos/compare_nitsche_snes.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
         else:
             fname = f"{mesh_dir}/disk"
             create_disk_mesh(filename=f"{fname}.msh")
-            convert_mesh(fname, fname, gdim=3)
+            convert_mesh(fname, fname, gdim=2)
             with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
                 mesh = xdmf.read_mesh()
 
@@ -111,7 +111,7 @@ if __name__ == "__main__":
                     "snes_max_fail": 10, "snes_type": "vinewtonrsls",
                     "snes_rtol": 1e-9, "snes_atol": 1e-9, "snes_view": None}
     # Cannot use GAMG with SNES, see: https://gitlab.com/petsc/petsc/-/issues/829
-    petsc_snes = {"ksp_type": "cg", "ksp_rtol": 1e-5, "pc_type": "jacobi"}
+    petsc_snes = {"ksp_type": "cg", "ksp_rtol": 1e-6, "pc_type": "jacobi"}
     e_abs = []
     e_rel = []
     dofs_global = []

--- a/python/demos/demo_nitsche_rigid_surface_ufl.py
+++ b/python/demos/demo_nitsche_rigid_surface_ufl.py
@@ -57,36 +57,32 @@ if __name__ == "__main__":
 
     # Load mesh and create identifier functions for the top (Displacement condition)
     # and the bottom (contact condition)
+    outdir = "meshes"
     if threed:
-        fname = "sphere"
+        fname = f"{outdir}/sphere"
         create_sphere_plane_mesh(filename=f"{fname}.msh")
-        convert_mesh(fname, fname, "tetra")
-        convert_mesh(f"{fname}", f"{fname}_facets", "triangle")
+        convert_mesh(fname, fname, gdim=3)
         with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-            mesh = xdmf.read_mesh(name="Grid")
-        tdim = mesh.topology.dim
-        mesh.topology.create_connectivity(tdim - 1, 0)
-        mesh.topology.create_connectivity(tdim - 1, tdim)
-        with XDMFFile(MPI.COMM_WORLD, f"{fname}_facets.xdmf", "r") as xdmf:
-            facet_marker = xdmf.read_meshtags(mesh, name="Grid")
+            mesh = xdmf.read_mesh()
+            tdim = mesh.topology.dim
+            mesh.topology.create_connectivity(tdim - 1, tdim)
+            facet_marker = xdmf.read_meshtags(mesh, name="facet_marker")
         top_value = 2
         bottom_value = 1
         surface_value = 8
         surface_bottom = 7
 
     else:
-        fname = "twomeshes"
+        fname = f"{outdir}/twomeshes"
         create_circle_plane_mesh(filename=f"{fname}.msh")
-        convert_mesh(fname, fname, "triangle", prune_z=True)
-        convert_mesh(f"{fname}", f"{fname}_facets", "line", prune_z=True)
+        convert_mesh(fname, fname, gdim=2)
 
         with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-            mesh = xdmf.read_mesh(name="Grid")
-        tdim = mesh.topology.dim
-        mesh.topology.create_connectivity(tdim - 1, 0)
-        mesh.topology.create_connectivity(tdim - 1, tdim)
-        with XDMFFile(MPI.COMM_WORLD, f"{fname}_facets.xdmf", "r") as xdmf:
-            facet_marker = xdmf.read_meshtags(mesh, name="Grid")
+            mesh = xdmf.read_mesh()
+            tdim = mesh.topology.dim
+            mesh.topology.create_connectivity(tdim - 1, tdim)
+            facet_marker = xdmf.read_meshtags(mesh, name="facet_marker")
+
         top_value = 2
         bottom_value = 4
         surface_value = 9

--- a/python/demos/gradual_loading.py
+++ b/python/demos/gradual_loading.py
@@ -60,18 +60,16 @@ if __name__ == "__main__":
     curved = args.curved
     # Load mesh and create identifier functions for the top (Displacement condition)
     # and the bottom (contact condition)
+    mesh_dir = "meshes"
     if threed:
-        fname = "sphere"
+        fname = f"{mesh_dir}/sphere"
         create_sphere_plane_mesh(filename=f"{fname}.msh")
-        convert_mesh(fname, fname, "tetra")
-        convert_mesh(f"{fname}", f"{fname}_facets", "triangle")
+        convert_mesh(fname, fname, gdim=3)
         with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-            mesh = xdmf.read_mesh(name="Grid")
-        tdim = mesh.topology.dim
-        mesh.topology.create_connectivity(tdim - 1, 0)
-        mesh.topology.create_connectivity(tdim - 1, tdim)
-        with XDMFFile(MPI.COMM_WORLD, f"{fname}_facets.xdmf", "r") as xdmf:
-            facet_marker = xdmf.read_meshtags(mesh, name="Grid")
+            mesh = xdmf.read_mesh()
+            tdim = mesh.topology.dim
+            mesh.topology.create_connectivity(tdim - 1, tdim)
+            facet_marker = xdmf.read_meshtags(mesh, name="facet_marker")
         top_value = 2
         bottom_value = 1
         surface_value = 8
@@ -79,13 +77,12 @@ if __name__ == "__main__":
 
     else:
         if curved:
-            fname = "two_disks"
+            fname = f"{mesh_dir}/two_disks"
             create_circle_circle_mesh(filename=f"{fname}.msh")
-            convert_mesh(fname, fname, "triangle", prune_z=True)
-            convert_mesh(f"{fname}", f"{fname}_facets", "line", prune_z=True)
+            convert_mesh(fname, fname, gdim=2)
 
             with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-                mesh = xdmf.read_mesh(name="Grid")
+                mesh = xdmf.read_mesh()
             tdim = mesh.topology.dim
             mesh.topology.create_connectivity(tdim - 1, 0)
             mesh.topology.create_connectivity(tdim - 1, tdim)
@@ -121,18 +118,15 @@ if __name__ == "__main__":
             sorted_facets = np.argsort(indices)
             facet_marker = meshtags(mesh, tdim - 1, indices[sorted_facets], values[sorted_facets])
         else:
-            fname = "twomeshes"
+            fname = f"{mesh_dir}/twomeshes"
             create_circle_plane_mesh(filename=f"{fname}.msh")
-            convert_mesh(fname, fname, "triangle", prune_z=True)
-            convert_mesh(f"{fname}", f"{fname}_facets", "line", prune_z=True)
+            convert_mesh(fname, fname, gdim=2)
 
             with XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-                mesh = xdmf.read_mesh(name="Grid")
-            tdim = mesh.topology.dim
-            mesh.topology.create_connectivity(tdim - 1, 0)
-            mesh.topology.create_connectivity(tdim - 1, tdim)
-            with XDMFFile(MPI.COMM_WORLD, f"{fname}_facets.xdmf", "r") as xdmf:
-                facet_marker = xdmf.read_meshtags(mesh, name="Grid")
+                mesh = xdmf.read_mesh()
+                tdim = mesh.topology.dim
+                mesh.topology.create_connectivity(tdim - 1, tdim)
+                facet_marker = xdmf.read_meshtags(mesh, name="facet_marker")
             top_value = 2
             bottom_value = 4
             surface_value = 9

--- a/python/dolfinx_contact/meshing/utils.py
+++ b/python/dolfinx_contact/meshing/utils.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier:    MIT
 
 from mpi4py import MPI
-import meshio
+import dolfinx.io
 
 
-def convert_mesh(filename: str, outname: str, cell_type: str, prune_z: bool = False, cell_data: str = "gmsh:physical"):
+def convert_mesh(filename: str, outname: str, gdim: int = 3):
     """
-    Read a GMSH mesh (msh format) and convert it to XDMF with only cells of input cell-type.
-    Name of output file will be the same as input file (.msh->.xdmf/.h5)
+    Read a GMSH mesh (msh format) and convert it to XDMF with both cell
+    and facet tags in a single file.
 
     Parameters
     ==========
@@ -17,21 +17,19 @@ def convert_mesh(filename: str, outname: str, cell_type: str, prune_z: bool = Fa
         Name of input file
     outname
         Name of output file
-    cell_type
-        The cell type
-    prune_z
-        Sets mesh geometrical dimension to 2 if True, else gdim=3
-    cell_data
-        Key to cell data dictionary in msh file
+    gdim
+        The geometrical dimension of the mesh
     """
     fname = filename.split(".msh")[0]
     oname = outname.split(".xdmf")[0]
 
     if MPI.COMM_WORLD.rank == 0:
-        mesh = meshio.read(f"{fname}.msh")
-        cells = mesh.get_cells_type(cell_type)
-        data = mesh.get_cell_data(cell_data, cell_type)
-        pts = mesh.points[:, :2] if prune_z else mesh.points
-        out_mesh = meshio.Mesh(points=pts, cells={cell_type: cells}, cell_data={"name_to_read": [data]})
-        meshio.write(f"{oname}.xdmf", out_mesh)
+        mesh, ct, ft = dolfinx.io.gmshio.read_from_msh(f"{fname}.msh", MPI.COMM_SELF, 0, gdim=gdim)
+        ct.name = "cell_marker"
+        ft.name = "facet_marker"
+        with dolfinx.io.XDMFFile(mesh.comm, f"{oname}.xdmf", "w") as xdmf:
+            xdmf.write_mesh(mesh)
+            xdmf.write_meshtags(ct)
+            mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
+            xdmf.write_meshtags(ft)
     MPI.COMM_WORLD.Barrier()

--- a/python/dolfinx_contact/one_sided/nitsche_ufl.py
+++ b/python/dolfinx_contact/one_sided/nitsche_ufl.py
@@ -132,6 +132,8 @@ def nitsche_ufl(mesh: dmesh.Mesh, mesh_data: Tuple[_cpp.mesh.MeshTags_int32, int
     J += 1 / gamma_scaled * 0.5 * (1 - ufl.sign(q)) * (sigma_n(du) - gamma_scaled * ufl.dot(du, n_2)) * \
         (theta * sigma_n(v) - gamma_scaled * ufl.dot(v, n_2)) * ds(bottom_value)
 
+    assert(mesh.geometry.dim == mesh.topology.dim)
+
     # Nitsche for Dirichlet, another theta-scheme.
     # https://doi.org/10.1016/j.cma.2018.05.024
     if nitsche_bc:

--- a/python/dolfinx_contact/one_sided/snes_against_plane.py
+++ b/python/dolfinx_contact/one_sided/snes_against_plane.py
@@ -99,6 +99,7 @@ def snes_solver(mesh: dmesh.Mesh, mesh_data: Tuple[_cpp.mesh.MeshTags_int32, int
     # # Yields same F as above if penalty = 0 and body force 0
     # F = ufl.derivative(Pi, u, v)
     assert(mesh.topology.dim == mesh.geometry.dim)
+
     # Dirichlet boundary conditions
     def _u_D(x):
         values = np.zeros((mesh.geometry.dim, x.shape[1]))

--- a/python/dolfinx_contact/one_sided/snes_against_plane.py
+++ b/python/dolfinx_contact/one_sided/snes_against_plane.py
@@ -98,7 +98,7 @@ def snes_solver(mesh: dmesh.Mesh, mesh_data: Tuple[_cpp.mesh.MeshTags_int32, int
     # # Compute first variation of Pi (directional derivative about u in the direction of v)
     # # Yields same F as above if penalty = 0 and body force 0
     # F = ufl.derivative(Pi, u, v)
-
+    assert(mesh.topology.dim == mesh.geometry.dim)
     # Dirichlet boundary conditions
     def _u_D(x):
         values = np.zeros((mesh.geometry.dim, x.shape[1]))

--- a/python/tests/test_dolfinx_cuas.py
+++ b/python/tests/test_dolfinx_cuas.py
@@ -13,7 +13,7 @@ import pytest
 import ufl
 from mpi4py import MPI
 from dolfinx.graph import create_adjacencylist
-
+import os
 import dolfinx_contact
 import dolfinx_contact.cpp
 from dolfinx_contact.helpers import (R_minus, epsilon, lame_parameters,
@@ -44,13 +44,15 @@ def test_contact_kernel(theta, gamma, dim, gap):
 
     # Load mesh and create identifier functions for the top (Displacement condition)
     # and the bottom (contact condition)
+    mesh_dir = "meshes"
+    os.system(f"mkdir -p {mesh_dir}")
     if dim == 3:
-        fname = "sphere"
+        fname = f"{mesh_dir}/sphere"
         create_sphere_mesh(filename=f"{fname}.msh")
-        convert_mesh(fname, fname, "tetra")
+        convert_mesh(fname, fname, gdim=3)
 
         with dolfinx.io.XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-            mesh = xdmf.read_mesh(name="Grid")
+            mesh = xdmf.read_mesh()
 
         def top(x):
             return x[2] > 0.9
@@ -59,11 +61,11 @@ def test_contact_kernel(theta, gamma, dim, gap):
             return x[2] < 0.15
 
     else:
-        fname = "disk"
+        fname = f"{mesh_dir}/disk"
         create_disk_mesh(filename=f"{fname}.msh")
-        convert_mesh(fname, fname, "triangle", prune_z=True)
+        convert_mesh(fname, fname, gdim=2)
         with dolfinx.io.XDMFFile(MPI.COMM_WORLD, f"{fname}.xdmf", "r") as xdmf:
-            mesh = xdmf.read_mesh(name="Grid")
+            mesh = xdmf.read_mesh()
 
         def top(x):
             return x[1] > 0.5


### PR DESCRIPTION
With the new gmsh interface we no longer need to rely on meshio/h5py for converting msh files.