### PR TITLE
update petsc options

### DIFF
--- a/python/demos/compare_custom_snes_one_sided.py
+++ b/python/demos/compare_custom_snes_one_sided.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     # petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "rtol": 1e-6, "pc_gamg_coarse_eq_limit": 1000,
     #                  "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "jacobi",
     #                  "mg_levels_esteig_ksp_type": "cg", "matptap_via": "scalable", "ksp_view": None}
-    snes_options = {"snes_monitor": None, "snes_max_it": 50, "snes_no_convergence_test": False,
+    snes_options = {"snes_monitor": None, "snes_max_it": 50,
                     "snes_max_fail": 10, "snes_type": "vinewtonrsls",
                     "snes_rtol": 1e-9, "snes_atol": 1e-9, "snes_view": None}
     # Cannot use GAMG with SNES, see: https://gitlab.com/petsc/petsc/-/issues/829

--- a/python/demos/compare_nitsche_snes.py
+++ b/python/demos/compare_nitsche_snes.py
@@ -104,10 +104,10 @@ if __name__ == "__main__":
             return x[1] < 0.2
 
     newton_options = {"relaxation_parameter": 0.8}
-    petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "rtol": 1e-6, "pc_gamg_coarse_eq_limit": 1000,
+    petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "pc_gamg_coarse_eq_limit": 1000,
                      "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "jacobi",
-                     "mg_levels_esteig_ksp_type": "cg", "matptap_via": "scalable", "ksp_view": None}
-    snes_options = {"snes_monitor": None, "snes_max_it": 50, "snes_no_convergence_test": False,
+                     "ksp_view": None}
+    snes_options = {"snes_monitor": None, "snes_max_it": 50,
                     "snes_max_fail": 10, "snes_type": "vinewtonrsls",
                     "snes_rtol": 1e-9, "snes_atol": 1e-9, "snes_view": None}
     # Cannot use GAMG with SNES, see: https://gitlab.com/petsc/petsc/-/issues/829

--- a/python/demos/demo_christmas_tree.py
+++ b/python/demos/demo_christmas_tree.py
@@ -225,9 +225,9 @@ if __name__ == "__main__":
         "pc_gamg_type": "agg",
         "pc_gamg_coarse_eq_limit": 100,
         "pc_gamg_agg_nsmooths": 1,
-        "pc_gamg_sym_graph": True,
         "pc_gamg_threshold": 1e-3,
         "pc_gamg_square_graph": 2,
+        "pc_gamg_reuse_interpolation": False
     }
 
     mode = ContactMode.Raytracing if args.raytracing \

--- a/python/demos/demo_nitsche_meshties.py
+++ b/python/demos/demo_nitsche_meshties.py
@@ -162,13 +162,11 @@ if __name__ == "__main__":
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
         "pc_mg_levels": 3,
-        "pc_mg_cycles": 1,   # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",
         "pc_gamg_type": "agg",
         "pc_gamg_coarse_eq_limit": 100,
         "pc_gamg_agg_nsmooths": 1,
-        "pc_gamg_sym_graph": True,
         "pc_gamg_threshold": 1e-3,
         "pc_gamg_square_graph": 2,
     }

--- a/python/demos/demo_nitsche_rigid_surface_custom.py
+++ b/python/demos/demo_nitsche_rigid_surface_custom.py
@@ -160,9 +160,9 @@ if __name__ == "__main__":
     # Solver options
     newton_options = {"relaxation_parameter": 1.0, "max_it": 50}
     # petsc_options = {"ksp_type": "preonly", "pc_type": "lu"}
-    petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "rtol": 1e-6, "pc_gamg_coarse_eq_limit": 1000,
+    petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "pc_gamg_coarse_eq_limit": 1000,
                      "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "jacobi",
-                     "mg_levels_esteig_ksp_type": "cg", "matptap_via": "scalable", "ksp_view": None}
+                     "matptap_via": "scalable", "ksp_view": None}
 
     # Pack mesh data for Nitsche solver
     mesh_data = (facet_marker, top_value, bottom_value, surface_value, surface_bottom)

--- a/python/demos/demo_nitsche_rigid_surface_ufl.py
+++ b/python/demos/demo_nitsche_rigid_surface_ufl.py
@@ -91,9 +91,9 @@ if __name__ == "__main__":
     # Solver options
     newton_options = {"relaxation_parameter": 1.0}
     # petsc_options = {"ksp_type": "preonly", "pc_type": "lu"}
-    petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "rtol": 1e-6, "pc_gamg_coarse_eq_limit": 1000,
+    petsc_options = {"ksp_type": "cg", "pc_type": "gamg", "pc_gamg_coarse_eq_limit": 1000,
                      "mg_levels_ksp_type": "chebyshev", "mg_levels_pc_type": "jacobi",
-                     "mg_levels_esteig_ksp_type": "cg", "matptap_via": "scalable", "ksp_view": None}
+                     "ksp_view": None}
 
     # Pack mesh data for Nitsche solver
     mesh_data = (facet_marker, top_value, bottom_value, surface_value, surface_bottom)

--- a/python/demos/demo_nitsche_unbiased.py
+++ b/python/demos/demo_nitsche_unbiased.py
@@ -315,9 +315,9 @@ if __name__ == "__main__":
         "pc_gamg_type": "agg",
         "pc_gamg_coarse_eq_limit": 100,
         "pc_gamg_agg_nsmooths": 1,
-        "pc_gamg_sym_graph": True,
         "pc_gamg_threshold": 1e-3,
         "pc_gamg_square_graph": 2,
+        "pc_gamg_reuse_interpolation": False
     }
     # Pack mesh data for Nitsche solver
     dirichlet_vals = [dirichlet_bdy_1, dirichlet_bdy_2]

--- a/python/demos/meshtie_convergence.py
+++ b/python/demos/meshtie_convergence.py
@@ -163,7 +163,6 @@ def unsplit_domain(threed: bool = False, runs: int = 1):
         opts["mg_levels_pc_type"] = "jacobi"
 
         # Improve estimate of eigenvalues for Chebyshev smoothing
-        opts["mg_levels_esteig_ksp_type"] = "cg"
         opts["mg_levels_ksp_chebyshev_esteig_steps"] = 20
 
         # Create PETSc Krylov solver and turn convergence monitoring on
@@ -248,7 +247,6 @@ def test_meshtie(threed: bool = False, simplex: bool = True, runs: int = 5):
         "pc_type": "gamg",
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",
-        "mg_levels_esteig_ksp_type": "cg",
         "pc_gamg_coarse_eq_limit": 100,
         "mg_levels_ksp_chebyshev_esteig_steps": 20
     }


### PR DESCRIPTION
With the most recent update, the default value of the preconditioner petsc option ```-pc_gamg_reuse_interpolation``` has been changed from false to true (see https://petsc.org/release/docs/changes/318/) leading to an indefinite preconditioner in some cases. This option has therefore been set to false in those cases.

Moreover, some petsc options that were flagged as unused have been removed.