### PR TITLE
Make code compile with 0.9.0

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -51,51 +51,14 @@ jobs:
     name: Build and test
     needs: lint
     runs-on: ubuntu-latest
-    container: ghcr.io/fenics/test-env:current-mpich
-    # strategy:
-    #   matrix:
-    #     # Complex mode not working
-    #     # run_mode: ["Release", "Debug"]
-    #     petsc_mode: ["real"]
-    #     petsc_precision: ["64"]
-    #     petsc_int: ["32"]
-    env:
-      # PETSC_ARCH: linux-gnu-${{ matrix.petsc_mode }}${{ matrix.petsc_precision}}-${{ matrix.petsc_int }}
-      PETSC_ARCH: linux-gnu-real64-32
-      # OMPI_ALLOW_RUN_AS_ROOT: 1
-      # OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      # OMPI_MCA_rmaps_base_oversubscribe: 1
-      # OMPI_MCA_plm: isolated
-      # OMPI_MCA_btl_vader_single_copy_mechanism: none
-      # OMPI_MCA_mpi_yield_when_idle: 1
-      # OMPI_MCA_hwloc_base_binding_policy: none
+    container: ghcr.io/fenics/dolfinx/dolfinx:stable
     steps:
       - uses: actions/checkout@v4
-
-      - name: Get DOLFINx
-        if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v4
-        with:
-          path: ./dolfinx
-          repository: FEniCS/dolfinx
-          ref: main
 
       - name: Build C++ docs
         run: |
           cd cpp/doc
           doxygen
-
-      - name: Install DOLFINx
-        run: |
-          pip install git+https://github.com/FEniCS/ufl.git
-          pip install git+https://github.com/FEniCS/basix.git
-          pip install git+https://github.com/FEniCS/ffcx.git
-
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/
-          cmake --build build
-          cmake --install build
-          pip install -r dolfinx/python/build-requirements.txt # TO REMOVE
-          pip -v install --check-build-dependencies --no-build-isolation dolfinx/python/
 
       - name: Install contact library (C++)
         id: cpp-contact

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ simulations. It builds on the
 
 dolfinx-contact is under heavy development and is highly experimental.
 
+## Installation
+DOLFINx contact requires DOLFINx (v0.9.0) installed on your system.
+To build the library, you can call:
+```bash
+
+```bash
+export VERBOSE=1
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer  -B build-contact -S cpp/
+ninja -C build-contact install
+```
+to install the C++ interface
+and
+```bash
+python3 -m pip -v install -r ./python/build-requirements.txt
+python3 -m pip -v install --no-build-isolation python/
+```
+to install the Python interface.
 
 ## Notes
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 # Set project name and version number
-project(DOLFINX_CONTACT VERSION 0.8.0.0)
+project(DOLFINX_CONTACT VERSION 0.9.0.0)
 
 # -----------------------------------------------------------------------------
 # Set CMake options, see `cmake --help-policy CMP00xx`
@@ -60,8 +60,8 @@ add_feature_info(
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Find packages
-find_package(DOLFINX 0.8.0.0 REQUIRED)
-find_package(Basix 0.8.0.0 REQUIRED)
+find_package(DOLFINX 0.9.0.0 REQUIRED)
+find_package(Basix 0.9.0.0 REQUIRED)
 
 feature_summary(WHAT ALL)
 

--- a/cpp/Contact.cpp
+++ b/cpp/Contact.cpp
@@ -108,7 +108,7 @@ void compute_linked_cells(
                 });
 
   // Remove duplicates
-  dolfinx::radix_sort(std::span<std::int32_t>(linked_cells));
+  dolfinx::radix_sort(linked_cells);
   linked_cells.erase(std::unique(linked_cells.begin(), linked_cells.end()),
                      linked_cells.end());
 }

--- a/cpp/SubMesh.cpp
+++ b/cpp/SubMesh.cpp
@@ -21,7 +21,7 @@ SubMesh::SubMesh(const dolfinx::mesh::Mesh<double>& mesh,
     cells[f] = cell_facet_pairs[2 * f];
 
   // sort cells and remove duplicates
-  dolfinx::radix_sort<std::int32_t>(std::span(cells.data(), cells.size()));
+  dolfinx::radix_sort(cells);
   cells.erase(std::unique(cells.begin(), cells.end()), cells.end());
 
   // save sorted cell vector as _parent_cells

--- a/cpp/demos/meshtie/main.cpp
+++ b/cpp/demos/meshtie/main.cpp
@@ -230,7 +230,6 @@ int main(int argc, char* argv[])
     dolfinx::la::petsc::KrylovSolver ksp(MPI_COMM_WORLD);
     dolfinx::la::petsc::options::set("ksp_type", "cg");
     dolfinx::la::petsc::options::set("pc_type", "gamg");
-    dolfinx::la::petsc::options::set("pc_mg_levels", 3);
     dolfinx::la::petsc::options::set("mg_levels_ksp_type", "chebyshev");
     dolfinx::la::petsc::options::set("mg_levels_pc_type", "jacobi");
     dolfinx::la::petsc::options::set("pc_gamg_type", "agg");

--- a/cpp/demos/meshtie/main.cpp
+++ b/cpp/demos/meshtie/main.cpp
@@ -154,10 +154,11 @@ int main(int argc, char* argv[])
     // Define variational forms
     auto J = std::make_shared<fem::Form<T>>(
         fem::create_form<T>(*form_linear_elasticity_J, {V, V},
-                            {{"mu", mu}, {"lmbda", lmbda}}, {}, {}));
+                            {{"mu", mu}, {"lmbda", lmbda}}, {}, {}, {}));
     auto F = std::make_shared<fem::Form<T>>(fem::create_form<T>(
         *form_linear_elasticity_F, {V}, {{"f", f}, {"t", t}}, {},
-        {{dolfinx::fem::IntegralType::exterior_facet, integration_domain}}));
+        {{dolfinx::fem::IntegralType::exterior_facet, integration_domain}},
+        {}));
 
     // Define boundary conditions
     const std::int32_t dirichlet_bdy = 12; // bottom face
@@ -198,7 +199,7 @@ int main(int argc, char* argv[])
     dolfinx::fem::apply_lifting<T, U>(b.mutable_array(), {J}, {{bc}}, {},
                                       double(1.0));
     b.scatter_rev(std::plus<T>());
-    dolfinx::fem::set_bc<T, U>(b.mutable_array(), {bc});
+    bc->set(b.mutable_array(), std::nullopt);
 
     // Assemble matrix
     MatZeroEntries(A.mat());

--- a/cpp/demos/meshtieHeatEquation/main.cpp
+++ b/cpp/demos/meshtieHeatEquation/main.cpp
@@ -87,9 +87,9 @@ int main(int argc, char* argv[])
     // Define variational forms
     auto a_therm = std::make_shared<fem::Form<T>>(
         fem::create_form<T>(*form_heat_equation_a_therm, {Q, Q},
-                            {{"T0", T0}, {"kdt", kdt}}, {}, {}));
+                            {{"T0", T0}, {"kdt", kdt}}, {}, {}, {}));
     auto L_therm = std::make_shared<fem::Form<T>>(fem::create_form<T>(
-        *form_heat_equation_L_therm, {Q}, {{"T0", T0}}, {}, {}));
+        *form_heat_equation_L_therm, {Q}, {{"T0", T0}}, {}, {}, {}));
 
     // Define boundary conditions
     const std::int32_t dirichlet_bdy = 2; // bottom face
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
       dolfinx::fem::apply_lifting<T, U>(b_therm.mutable_array(), {a_therm},
                                         {{bc}}, {}, double(1.0));
       b_therm.scatter_rev(std::plus<T>());
-      dolfinx::fem::set_bc<T, U>(b_therm.mutable_array(), {bc});
+      bc->set(b_therm.mutable_array(), std::nullopt);
 
       // Assemble matrix
       MatZeroEntries(A_therm.mat());

--- a/cpp/demos/meshtieHeatEquation/main.cpp
+++ b/cpp/demos/meshtieHeatEquation/main.cpp
@@ -126,7 +126,6 @@ int main(int argc, char* argv[])
     dolfinx::la::petsc::KrylovSolver ksp_therm(MPI_COMM_WORLD);
     dolfinx::la::petsc::options::set("ksp_type", "cg");
     dolfinx::la::petsc::options::set("pc_type", "gamg");
-    dolfinx::la::petsc::options::set("pc_mg_levels", 2);
     dolfinx::la::petsc::options::set("mg_levels_ksp_type", "chebyshev");
     dolfinx::la::petsc::options::set("mg_levels_pc_type", "jacobi");
     dolfinx::la::petsc::options::set("pc_gamg_type", "agg");

--- a/cpp/demos/meshtieHeatTransfer/main.cpp
+++ b/cpp/demos/meshtieHeatTransfer/main.cpp
@@ -336,7 +336,6 @@ int main(int argc, char* argv[])
     dolfinx::la::petsc::KrylovSolver ksp_therm(MPI_COMM_WORLD);
     dolfinx::la::petsc::options::set("ksp_type", "cg");
     dolfinx::la::petsc::options::set("pc_type", "gamg");
-    dolfinx::la::petsc::options::set("pc_mg_levels", 2);
     dolfinx::la::petsc::options::set("mg_levels_ksp_type", "chebyshev");
     dolfinx::la::petsc::options::set("mg_levels_pc_type", "jacobi");
     dolfinx::la::petsc::options::set("pc_gamg_type", "agg");

--- a/cpp/demos/meshtieHeatTransfer/main.cpp
+++ b/cpp/demos/meshtieHeatTransfer/main.cpp
@@ -502,8 +502,7 @@ int main(int argc, char* argv[])
       dolfinx::fem::apply_lifting<T, U>(b_therm.mutable_array(), {a_therm},
                                         {{bcs_therm}}, {}, double(1.0));
       b_therm.scatter_rev(std::plus<T>());
-      for (auto& bc : bcs)
-        bc->set(b_therm.mutable_array(), std::nullopt);
+      bcs_therm->set(b_therm.mutable_array(), std::nullopt);
 
       // Assemble matrix
       MatZeroEntries(A_therm.mat());

--- a/cpp/demos/meshtieNewton/main.cpp
+++ b/cpp/demos/meshtieNewton/main.cpp
@@ -137,7 +137,7 @@ public:
       VecGhostUpdateEnd(_b_petsc, ADD_VALUES, SCATTER_REVERSE);
 
       // Set bc
-      fem::set_bc<T, U>(b, _bcs, std::span<const T>(array, n), -1.0);
+      fem::petsc::set_bc<T>(_b_petsc, _bcs, x, -1.0);
       VecRestoreArrayRead(x, &array);
 
       // log level INFO ensures Newton steps are logged
@@ -300,13 +300,14 @@ int main(int argc, char* argv[])
     // Define variational forms
     auto J = std::make_shared<fem::Form<T>>(
         fem::create_form<T>(*form_linear_elasticity_J, {V, V},
-                            {{"mu", mu}, {"lmbda", lmbda}}, {}, {}));
+                            {{"mu", mu}, {"lmbda", lmbda}}, {}, {}, {}));
 
     auto u = std::make_shared<fem::Function<T>>(V);
     auto F = std::make_shared<fem::Form<T>>(fem::create_form<T>(
         *form_linear_elasticity_F, {V},
         {{"u", u}, {"mu", mu}, {"lmbda", lmbda}}, {},
-        {{dolfinx::fem::IntegralType::exterior_facet, integration_domain}}));
+        {{dolfinx::fem::IntegralType::exterior_facet, integration_domain}},
+        {}));
 
     // Define boundary conditions
     // bottom fixed, top displaced in y-diretion by -0.2

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier:    MIT
 
+#include<algorithm>
 #include "utils.h"
 #include "RayTracing.h"
 #include "error_handling.h"

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -194,7 +194,7 @@ dolfinx_contact::sort_cells(std::span<const std::int32_t> cells,
   std::vector<std::int32_t> unique_cells(num_cells);
   std::vector<std::int32_t> offsets(num_cells + 1, 0);
   std::iota(perm.begin(), perm.end(), 0);
-  dolfinx::argsort_radix<std::int32_t>(cells, perm);
+  dolfinx::radix_sort(perm, [&cells](auto index) { return cells[index]; });
 
   // Sort cells in accending order
   for (std::int32_t i = 0; i < num_cells; ++i)
@@ -664,7 +664,7 @@ std::vector<std::int32_t> dolfinx_contact::compute_active_entities(
   case dolfinx::fem::IntegralType::cell:
   {
     std::vector<std::int32_t> active_entities(entities.begin(), entities.end());
-    dolfinx::radix_sort(std::span<std::int32_t>(active_entities));
+    dolfinx::radix_sort(active_entities);
     return active_entities;
   }
   case dolfinx::fem::IntegralType::exterior_facet:
@@ -694,7 +694,7 @@ std::vector<std::int32_t> dolfinx_contact::compute_active_entities(
 
     std::vector<std::int32_t> perm(entities.size());
     std::iota(perm.begin(), perm.end(), 0);
-    dolfinx::argsort_radix<std::int32_t>(cells, perm);
+    dolfinx::radix_sort(perm, [&cells](auto index) { return cells[index]; });
 
     // Sort cells in ascending order
     std::vector<std::int32_t> active_entities;
@@ -1135,7 +1135,7 @@ MatNullSpace dolfinx_contact::build_nullspace_multibody(
       std::copy_n(cell_dofs.begin(), ndofs_cell, dofs.begin() + c * ndofs_cell);
     }
     // Remove duplicates
-    dolfinx::radix_sort(std::span<std::int32_t>(dofs));
+    dolfinx::radix_sort(dofs);
     dofs.erase(std::unique(dofs.begin(), dofs.end()), dofs.end());
 
     // Translations

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -473,7 +473,7 @@ void dolfinx_contact::evaluate_basis_functions(
   std::array<std::size_t, 4> shape
       = {1, num_cells, space_dimension, reference_value_size};
   if (num_derivatives == 1)
-    shape[0] = tdim + 1;
+    shape[0] = gdim + 1;
   std::vector<double> tempb(
       std::reduce(shape.cbegin(), shape.cend(), 1, std::multiplies{}));
   mdspan_t<double, 4> temp(tempb.data(), shape);

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -189,6 +189,12 @@ std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
 dolfinx_contact::sort_cells(std::span<const std::int32_t> cells,
                             std::span<std::int32_t> perm)
 {
+  if (cells.size() == 0)
+  {
+    std::vector<std::int32_t> unique_cells(0);
+    std::vector<std::int32_t> offsets = {0,0};
+    return std::make_pair(unique_cells, offsets);
+  }
   assert(perm.size() == cells.size());
 
   // FIXME: Workaround for the case when all cells are -1

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2022 Jørgen S. Dokken and Sarah Roggendorf
+// Copyright (C) 2021-2025 Jørgen S. Dokken and Sarah Roggendorf
 //
 // This file is part of DOLFINx_CONTACT
 //
@@ -201,11 +201,15 @@ dolfinx_contact::sort_cells(std::span<const std::int32_t> cells,
     std::vector<std::int32_t> offsets = {0, (std::int32_t)cells.size()};
     return std::make_pair(unique_cells, offsets);
   }
+  // FIXME: Remove when https://github.com/FEniCS/dolfinx/pull/3724 is merged and released
+  if (*std::min_element(tmp_cells.cbegin(), tmp_cells.cend())<0)
+    throw std::runtime_error("Cell indices are negative, cannot sort with current algortihm.");
 
   const auto num_cells = (std::int32_t)cells.size();
   std::vector<std::int32_t> unique_cells(num_cells);
   std::vector<std::int32_t> offsets(num_cells + 1, 0);
   std::iota(perm.begin(), perm.end(), 0);
+
   dolfinx::radix_sort(perm, [&cells](auto index) { return cells[index]; });
   // Sort cells in accending order
   for (std::int32_t i = 0; i < num_cells; ++i)

--- a/python/demos/box_key_3D.py
+++ b/python/demos/box_key_3D.py
@@ -201,7 +201,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/box_key_3D.py
+++ b/python/demos/box_key_3D.py
@@ -299,7 +299,7 @@ if __name__ == "__main__":
     for i in range(nload_steps):
         t.interpolate(lambda x, j=i: _torque(x, (j + 1) / nload_steps))
         f.value[:] = (i + 1) * np.array(f_val) / nload_steps
-        timing_str = f"~Contact: {i+1} Newton Solver"
+        timing_str = f"~Contact: {i + 1} Newton Solver"
         with Timer(timing_str):
             n, converged = newton_solver.solve(du, write_solution=True)
         num_newton_its[i] = n

--- a/python/demos/debug.py
+++ b/python/demos/debug.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
         if i > 0:
             # Refine mesh
             mesh.topology.create_entities(mesh.topology.dim - 2)
-            mesh = refine(mesh)
+            mesh, _, _ = refine(mesh)
 
         # Create meshtag for top and bottom markers
         tdim = mesh.topology.dim

--- a/python/demos/debug.py
+++ b/python/demos/debug.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
         u2_L2 = np.sqrt(mesh.comm.allreduce(assemble_scalar(u2_norm), op=MPI.SUM))
         if rank == 0:
             print(f"abs. L2-error={E_L2:.2e}")
-            print(f"rel. L2-error={E_L2/u2_L2:.2e}")
+            print(f"rel. L2-error={E_L2 / u2_L2:.2e}")
         e_abs.append(E_L2)
         e_rel.append(E_L2 / u2_L2)
         dofs_global.append(V.dofmap.index_map.size_global * V.dofmap.index_map_bs)

--- a/python/demos/demo_christmas_tree_3D.py
+++ b/python/demos/demo_christmas_tree_3D.py
@@ -334,7 +334,7 @@ if __name__ == "__main__":
     for i in range(nload_steps):
         t.value[:] = (i + 1) * np.array(t_val) / nload_steps
         f.value[:] = (i + 1) * np.array(f_val) / nload_steps
-        timing_str = f"~Contact: {i+1} Newton Solver"
+        timing_str = f"~Contact: {i + 1} Newton Solver"
         with Timer(timing_str):
             n, converged = newton_solver.solve(du, write_solution=True)
         num_newton_its[i] = n

--- a/python/demos/demo_christmas_tree_3D.py
+++ b/python/demos/demo_christmas_tree_3D.py
@@ -234,7 +234,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/demo_christmas_tree_3D.py
+++ b/python/demos/demo_christmas_tree_3D.py
@@ -288,7 +288,7 @@ if __name__ == "__main__":
 
         # Apply boundary condition
         if len(bcs) > 0:
-            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], scale=-1.0)
+            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], alpha=-1.0)
         b.ghostUpdate(addv=InsertMode.ADD, mode=ScatterMode.REVERSE)
         if len(bcs) > 0:
             set_bc(b, bcs, x, -1.0)

--- a/python/demos/demo_nitsche_meshties.py
+++ b/python/demos/demo_nitsche_meshties.py
@@ -263,8 +263,9 @@ def run_demo(simplex, E, nu, gamma, theta, lifting, outfile, ksp_view, timing_vi
         ofile = open(outfile, "a")
     print("-" * 25, file=ofile)
     print(
-        f"num_dofs: {uh.function_space.dofmap.index_map_bs
-                     * uh.function_space.dofmap.index_map.size_global}"
+        f"num_dofs: {
+            uh.function_space.dofmap.index_map_bs * uh.function_space.dofmap.index_map.size_global
+        }"
         + f", {mesh.topology.cell_type}",
         file=ofile,
     )

--- a/python/demos/demo_nitsche_meshties.py
+++ b/python/demos/demo_nitsche_meshties.py
@@ -153,7 +153,6 @@ def run_demo(simplex, E, nu, gamma, theta, lifting, outfile, ksp_view, timing_vi
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",
         "pc_gamg_type": "agg",

--- a/python/demos/demo_nitsche_meshties.py
+++ b/python/demos/demo_nitsche_meshties.py
@@ -197,7 +197,7 @@ def run_demo(simplex, E, nu, gamma, theta, lifting, outfile, ksp_view, timing_vi
 
     # Apply boundary condition and scatter reverse
     if len(bcs) > 0:
-        apply_lifting(b, [J], bcs=[bcs], scale=-1.0)
+        apply_lifting(b, [J], bcs=[bcs], alpha=-1.0)
     b.ghostUpdate(
         addv=PETSc.InsertMode.ADD,  # type: ignore
         mode=PETSc.ScatterMode.REVERSE,  # type: ignore

--- a/python/demos/demo_nitsche_unbiased.py
+++ b/python/demos/demo_nitsche_unbiased.py
@@ -327,7 +327,6 @@ def run_soler(args):
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/demo_nitsche_unbiased.py
+++ b/python/demos/demo_nitsche_unbiased.py
@@ -494,7 +494,7 @@ def run_soler(args):
                 g.value[:] = displacement[k, :] / nload_steps
             else:
                 g.value[:] = (i + 1) * displacement[k, :] / nload_steps
-        timing_str = f"~Contact: {i+1} Newton Solver"
+        timing_str = f"~Contact: {i + 1} Newton Solver"
         with Timer(timing_str):
             n, converged = newton_solver.solve(du, write_solution=True)
         num_newton_its[i] = n
@@ -541,8 +541,9 @@ def run_soler(args):
         print("-" * 25, file=outfile)
         print(f"Newton options {newton_options}", file=outfile)
         print(
-            f"num_dofs: {u.function_space.dofmap.index_map_bs
-                         * u.function_space.dofmap.index_map.size_global}"
+            f"num_dofs: {
+                u.function_space.dofmap.index_map_bs * u.function_space.dofmap.index_map.size_global
+            }"
             + f", {mesh.topology.cell_type}",
             file=outfile,
         )

--- a/python/demos/demo_nitsche_unbiased.py
+++ b/python/demos/demo_nitsche_unbiased.py
@@ -444,7 +444,7 @@ def run_soler(args):
 
         # Apply boundary condition
         if len(bcs) > 0:
-            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], scale=-1.0)
+            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], alpha=-1.0)
         b.ghostUpdate(addv=InsertMode.ADD, mode=ScatterMode.REVERSE)
         if len(bcs) > 0:
             set_bc(b, bcs, x, -1.0)

--- a/python/demos/demo_sliding_wedges.py
+++ b/python/demos/demo_sliding_wedges.py
@@ -181,7 +181,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/demo_sliding_wedges.py
+++ b/python/demos/demo_sliding_wedges.py
@@ -224,7 +224,7 @@ if __name__ == "__main__":
 
         # Apply boundary condition
         if len(bcs) > 0:
-            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], scale=-1.0)
+            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], alpha=-1.0)
         b.ghostUpdate(addv=InsertMode.ADD, mode=ScatterMode.REVERSE)
         if len(bcs) > 0:
             set_bc(b, bcs, x, -1.0)

--- a/python/demos/demo_thermo_mech_boxkey3D.py
+++ b/python/demos/demo_thermo_mech_boxkey3D.py
@@ -74,7 +74,6 @@ petsc_options = {
     "ksp_rtol": ksp_tol,
     "ksp_atol": ksp_tol,
     "pc_type": "gamg",
-    "pc_mg_levels": 3,
     "pc_mg_cycles": 1,  # 1 is v, 2 is w
     "mg_levels_ksp_type": "chebyshev",
     "mg_levels_pc_type": "jacobi",

--- a/python/demos/demo_thermo_mech_xmas2D.py
+++ b/python/demos/demo_thermo_mech_xmas2D.py
@@ -170,7 +170,6 @@ petsc_options = {
     "ksp_rtol": ksp_tol,
     "ksp_atol": ksp_tol,
     "pc_type": "gamg",
-    "pc_mg_levels": 3,
     "pc_mg_cycles": 1,  # 1 is v, 2 is w
     "mg_levels_ksp_type": "chebyshev",
     "mg_levels_pc_type": "jacobi",

--- a/python/demos/hertz_contact/demo_friction_cylinders.py
+++ b/python/demos/hertz_contact/demo_friction_cylinders.py
@@ -340,7 +340,9 @@ if __name__ == "__main__":
     for i in range(steps1):
         g_top.value[1] = -0.2 / steps1
         t.value[1] = 0  # val
-        print(f"Fricitionless part: Step {i+1} of {steps1}----------------------------------------")
+        print(
+            f"Fricitionless part: Step {i + 1} of {steps1}----------------------------------------"
+        )
         set_bc(du.x.petsc_vec, bcs)
         n, converged = newton_solver.solve(du, write_solution=True)
         newton_steps1.append(n)
@@ -430,7 +432,9 @@ if __name__ == "__main__":
 
     newton_steps2 = []
     for i in range(steps2):
-        print(f"Fricitional part: Step {i+1} of {steps2}------------------------------------------")
+        print(
+            f"Fricitional part: Step {i + 1} of {steps2}------------------------------------------"
+        )
         set_bc(du.x.petsc_vec, bcs)
         g_top.value[0] = 6 * 0.05 / steps2
         n, converged = newton_solver.solve(du, write_solution=True)

--- a/python/demos/hertz_contact/demo_friction_cylinders.py
+++ b/python/demos/hertz_contact/demo_friction_cylinders.py
@@ -137,7 +137,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",
@@ -389,7 +388,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/hertz_contact/demo_friction_cylinders.py
+++ b/python/demos/hertz_contact/demo_friction_cylinders.py
@@ -280,7 +280,7 @@ if __name__ == "__main__":
 
         # Apply boundary condition
         if len(bcs) > 0:
-            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], scale=-1.0)
+            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], alpha=-1.0)
         b.ghostUpdate(addv=InsertMode.ADD, mode=ScatterMode.REVERSE)
         if len(bcs) > 0:
             set_bc(b, bcs, x, -1.0)

--- a/python/demos/hertz_contact/demo_friction_cylinders_force_driven.py
+++ b/python/demos/hertz_contact/demo_friction_cylinders_force_driven.py
@@ -134,7 +134,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",
@@ -367,7 +366,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/hertz_contact/demo_friction_cylinders_force_driven.py
+++ b/python/demos/hertz_contact/demo_friction_cylinders_force_driven.py
@@ -276,7 +276,7 @@ if __name__ == "__main__":
 
         # Apply boundary condition
         if len(bcs) > 0:
-            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], scale=-1.0)
+            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], alpha=-1.0)
         b.ghostUpdate(addv=InsertMode.ADD, mode=ScatterMode.REVERSE)
         if len(bcs) > 0:
             set_bc(b, bcs, x, -1.0)

--- a/python/demos/hertz_contact/demo_friction_cylinders_force_driven.py
+++ b/python/demos/hertz_contact/demo_friction_cylinders_force_driven.py
@@ -329,7 +329,7 @@ if __name__ == "__main__":
         val = -p * (i + 1) / steps1  # -0.2 / steps1  #
         t.value[1] = val
         print(
-            f"Fricitionless part: Step {i+1} of {steps1}------------------------------------------"
+            f"Fricitionless part: Step {i + 1} of {steps1}-----------------------------------------"
         )
         set_bc(du.x.petsc_vec, bcs)
         n, converged = newton_solver.solve(du, write_solution=True)
@@ -402,7 +402,9 @@ if __name__ == "__main__":
 
     newton_steps2 = []
     for i in range(steps2):
-        print(f"Fricitional part: Step {i+1} of {steps2}------------------------------------------")
+        print(
+            f"Fricitional part: Step {i + 1} of {steps2}------------------------------------------"
+        )
         # print(problem1.du.x.array[:])
         set_bc(du.x.petsc_vec, bcs)
         val = q_tan * (i + 1) / steps2

--- a/python/demos/hertz_contact/demo_hertzian_contact.py
+++ b/python/demos/hertz_contact/demo_hertzian_contact.py
@@ -330,7 +330,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/hertz_contact/demo_hertzian_contact.py
+++ b/python/demos/hertz_contact/demo_hertzian_contact.py
@@ -434,7 +434,7 @@ if __name__ == "__main__":
 
         # Apply boundary condition
         if len(bcs) > 0:
-            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], scale=-1.0)
+            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], alpha=-1.0)
         b.ghostUpdate(addv=InsertMode.ADD, mode=ScatterMode.REVERSE)
         if len(bcs) > 0:
             set_bc(b, bcs, x, -1.0)

--- a/python/demos/meshtie_demos/blocks_nitsche_meshtie.py
+++ b/python/demos/meshtie_demos/blocks_nitsche_meshtie.py
@@ -142,7 +142,7 @@ class MeshTieProblem:
         assemble_vector(self._b_petsc, self._l)  # standard kernels
 
         # Apply boundary condition
-        apply_lifting(self._b_petsc, [self._j], bcs=[self._bcs], x0=[x], scale=-1.0)
+        apply_lifting(self._b_petsc, [self._j], bcs=[self._bcs], x0=[x], alpha=-1.0)
         self._b_petsc.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
         set_bc(self._b_petsc, self._bcs, x, -1.0)
 

--- a/python/demos/meshtie_demos/demo_poisson.py
+++ b/python/demos/meshtie_demos/demo_poisson.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
 
     # Apply boundary condition and scatter reverse
     if len(bcs) > 0:
-        apply_lifting(b, [J], bcs=[bcs], scale=-1.0)
+        apply_lifting(b, [J], bcs=[bcs], alpha=-1.0)
     b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)  # type: ignore
     if len(bcs) > 0:
         set_bc(b, bcs)

--- a/python/demos/meshtie_demos/demo_poisson.py
+++ b/python/demos/meshtie_demos/demo_poisson.py
@@ -200,7 +200,6 @@ if __name__ == "__main__":
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/meshtie_demos/demo_poisson.py
+++ b/python/demos/meshtie_demos/demo_poisson.py
@@ -307,8 +307,9 @@ if __name__ == "__main__":
         outfile = open(args.outfile, "a")
     print("-" * 25, file=outfile)
     print(
-        f"num_dofs: {uh.function_space.dofmap.index_map_bs
-                     * uh.function_space.dofmap.index_map.size_global}"
+        f"num_dofs: {
+            uh.function_space.dofmap.index_map_bs * uh.function_space.dofmap.index_map.size_global
+        }"
         + f", {mesh.topology.cell_types[0]}",
         file=outfile,
     )

--- a/python/demos/meshtie_demos/thermo_mech.py
+++ b/python/demos/meshtie_demos/thermo_mech.py
@@ -167,7 +167,7 @@ class ThermoElasticProblem:
         assemble_vector(self._b_petsc, self._l)  # standard kernels
 
         # Apply boundary condition
-        apply_lifting(self._b_petsc, [self._j], bcs=[self._bcs], x0=[x], scale=-1.0)
+        apply_lifting(self._b_petsc, [self._j], bcs=[self._bcs], x0=[x], alpha=-1.0)
         self._b_petsc.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
         set_bc(self._b_petsc, self._bcs, x, -1.0)
 
@@ -334,7 +334,7 @@ def assemble_vec_therm(b):
     assemble_vector(b, L_therm)
 
     # Apply boundary condition and scatter reverse
-    apply_lifting(b, [a_therm], bcs=[[Tbc]], scale=1.0)
+    apply_lifting(b, [a_therm], bcs=[[Tbc]], alpha=1.0)
     b.ghostUpdate(
         addv=PETSc.InsertMode.ADD,  # type: ignore
         mode=PETSc.ScatterMode.REVERSE,

--- a/python/demos/new_demo_christmas_tree.py
+++ b/python/demos/new_demo_christmas_tree.py
@@ -337,7 +337,7 @@ def run_solver(
 
         # Apply boundary condition
         if len(bcs) > 0:
-            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], scale=-1.0)
+            apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], alpha=-1.0)
         b.ghostUpdate(addv=InsertMode.ADD, mode=ScatterMode.REVERSE)
         if len(bcs) > 0:
             set_bc(b, bcs, x, -1.0)

--- a/python/demos/new_demo_christmas_tree.py
+++ b/python/demos/new_demo_christmas_tree.py
@@ -274,7 +274,6 @@ def run_solver(
         "ksp_rtol": ksp_tol,
         "ksp_atol": ksp_tol,
         "pc_type": "gamg",
-        "pc_mg_levels": 3,
         "pc_mg_cycles": 1,  # 1 is v, 2 is w
         "mg_levels_ksp_type": "chebyshev",
         "mg_levels_pc_type": "jacobi",

--- a/python/demos/new_demo_christmas_tree.py
+++ b/python/demos/new_demo_christmas_tree.py
@@ -383,7 +383,7 @@ def run_solver(
     for i in range(nload_steps):
         t.value[:] = (i + 1) * np.array(t_val) / nload_steps
         f.value[:] = (i + 1) * np.array(f_val) / nload_steps
-        timing_str = f"~Contact: {i+1} Newton Solver"
+        timing_str = f"~Contact: {i + 1} Newton Solver"
         with Timer(timing_str):
             n, converged = newton_solver.solve(du, write_solution=True)
         num_newton_its[i] = n
@@ -431,8 +431,10 @@ def run_solver(
         print("-" * 25, file=outfile)
         print(f"Newton options {newton_options}", file=outfile)
         print(
-            f"num_dofs: {u1.function_space.dofmap.index_map_bs
-                         * u1.function_space.dofmap.index_map.size_global}"
+            f"num_dofs: {
+                u1.function_space.dofmap.index_map_bs
+                * u1.function_space.dofmap.index_map.size_global
+            }"
             + f", {mesh.topology.cell_type}",
             file=outfile,
         )

--- a/python/demos/new_demo_compare_nitsche_snes.py
+++ b/python/demos/new_demo_compare_nitsche_snes.py
@@ -119,7 +119,7 @@ def run_solver(
         if i > 0:
             # Refine mesh
             mesh.topology.create_entities(mesh.topology.dim - 2)
-            mesh = refine(mesh)
+            mesh, _, _ = refine(mesh)
 
         # Create meshtag for top and bottom markers
         tdim = mesh.topology.dim

--- a/python/demos/new_demo_compare_nitsche_snes.py
+++ b/python/demos/new_demo_compare_nitsche_snes.py
@@ -177,7 +177,7 @@ def run_solver(
         u2_L2 = np.sqrt(mesh.comm.allreduce(assemble_scalar(u2_norm), op=MPI.SUM))
         if rank == 0:
             print(f"abs. L2-error={E_L2:.2e}")
-            print(f"rel. L2-error={E_L2/u2_L2:.2e}")
+            print(f"rel. L2-error={E_L2 / u2_L2:.2e}")
 
         e_abs.append(E_L2)
         e_rel.append(E_L2 / u2_L2)

--- a/python/demos/new_demo_custom_snes_one_sided.py
+++ b/python/demos/new_demo_custom_snes_one_sided.py
@@ -118,7 +118,7 @@ def solver(
         if i > 0:
             # Refine mesh
             mesh.topology.create_entities(mesh.topology.dim - 2)
-            mesh = refine(mesh)
+            mesh, _, _ = refine(mesh)
 
         # Create meshtag for top and bottom markers
         tdim = mesh.topology.dim

--- a/python/demos/new_demo_custom_snes_one_sided.py
+++ b/python/demos/new_demo_custom_snes_one_sided.py
@@ -169,7 +169,7 @@ def solver(
         u2_L2 = np.sqrt(mesh.comm.allreduce(assemble_scalar(u2_norm), op=MPI.SUM))
         if rank == 0:
             print(f"abs. L2-error={E_L2:.2e}")
-            print(f"rel. L2-error={E_L2/u2_L2:.2e}")
+            print(f"rel. L2-error={E_L2 / u2_L2:.2e}")
         e_abs.append(E_L2)
         e_rel.append(E_L2 / u2_L2)
         dofs_global.append(V.dofmap.index_map.size_global * V.dofmap.index_map_bs)

--- a/python/demos/new_demo_nitsche_euler_bernoulli.py
+++ b/python/demos/new_demo_nitsche_euler_bernoulli.py
@@ -162,9 +162,9 @@ def solve_euler_bernoulli(
         uz = (rho_g * L**4) / (8 * E * In)
         print(
             f"-----{nx}x{ny}--Nitsche:{nitsche} (gamma: {gamma})----\n",
-            f"Maximal deflection: {u_at_point[mesh.geometry.dim-1]}\n",
+            f"Maximal deflection: {u_at_point[mesh.geometry.dim - 1]}\n",
             f"Theoretical deflection: {-uz}\n",
-            f"Error: {100*abs((u_at_point[mesh.geometry.dim-1]+uz)/uz)} %",
+            f"Error: {100 * abs((u_at_point[mesh.geometry.dim - 1] + uz) / uz)} %",
             flush=True,
         )
 

--- a/python/demos/oxford/blocks_nitsche.py
+++ b/python/demos/oxford/blocks_nitsche.py
@@ -196,7 +196,7 @@ def compute_residual(x, b, coeffs):
     b.ghostUpdate(addv=InsertMode.INSERT, mode=ScatterMode.FORWARD)
     contact_problem.assemble_vector(b, V)
     assemble_vector(b, F_compiled)
-    apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], scale=-1.0)
+    apply_lifting(b, [J_compiled], bcs=[bcs], x0=[x], alpha=-1.0)
     b.ghostUpdate(addv=InsertMode.ADD, mode=ScatterMode.REVERSE)
     set_bc(b, bcs, x, -1.0)
 

--- a/python/demos/oxford/blocks_nitsche.py
+++ b/python/demos/oxford/blocks_nitsche.py
@@ -161,7 +161,6 @@ petsc_options = {
     "ksp_rtol": ksp_tol,
     "ksp_atol": ksp_tol,
     "pc_type": "gamg",
-    "pc_mg_levels": 3,
     "pc_mg_cycles": 1,  # 1 is v, 2 is w
     "mg_levels_ksp_type": "chebyshev",
     "mg_levels_pc_type": "jacobi",

--- a/python/dolfinx_contact/helpers.py
+++ b/python/dolfinx_contact/helpers.py
@@ -173,7 +173,7 @@ class NonlinearPDE_SNESProblem:
         with F.localForm() as f_local:
             f_local.set(0.0)
         assemble_vector(F, self.L)
-        apply_lifting(F, [self.a], bcs=[[self.bc]], x0=[x], scale=-1.0)
+        apply_lifting(F, [self.a], bcs=[[self.bc]], x0=[x], alpha=-1.0)
         F.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
         set_bc(F, [self.bc], x, -1.0)
 

--- a/python/dolfinx_contact/newton_solver.py
+++ b/python/dolfinx_contact/newton_solver.py
@@ -105,7 +105,8 @@ class NewtonSolver:
         self.krylov_solver.setFromOptions()
         pc = self.krylov_solver.getPC()
         if pc_opts.get("pc_mg_levels") is not None:
-            pc.setMGLevels(pc_opts.get("pc_mg_levels"))
+            if pc.getType() != "gamg":
+                pc.setMGLevels(pc_opts.get("pc_mg_levels"))
             if pc_opts.get("pc_mg_cycles") is not None:
                 pc.setMGCycleType(pc_opts.get("pc_mg_cycles"))
         self._A.setOptionsPrefix(self.krylov_solver.getOptionsPrefix())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "dolfinx_contact"
-version = "0.8.0.dev0"
+version = "0.9.0"
 description = 'Contact custom assemblers using DOLFINx and Basix'
 readme = "README.md"
 requires-python = ">=3.8.0"
@@ -26,7 +26,7 @@ dependencies = [
       "cffi",
       # "petsc4py",
       "mpi4py",
-      "fenics-dolfinx>=0.8.0",
+      "fenics-dolfinx>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/python/tests/test_circumradius.py
+++ b/python/tests/test_circumradius.py
@@ -74,4 +74,5 @@ def test_circumradius(dim):
 
     # sort h2, compute_active_entities sorts by cells
     indices = np.argsort(cells)
-    np.testing.assert_allclose(h, h2[indices])
+    eps = np.finfo(mesh.geometry.x.dtype).eps
+    np.testing.assert_allclose(h, h2[indices], atol=eps)

--- a/python/tests/test_coeffs.py
+++ b/python/tests/test_coeffs.py
@@ -69,18 +69,18 @@ def test_pack_coeff_at_quadrature(ct, quadrature_degree, space, degree):
     # Use Expression to verify packing
     expr = Expression(v, quadrature_points)
     expr_vals = expr.eval(mesh, cells)
-    assert np.allclose(coeffs, expr_vals)
+    np.testing.assert_allclose(coeffs, expr_vals)
 
     if space not in ["N1curl", "RTCE"]:
         coeffs = dolfinx_contact.cpp.pack_gradient_quadrature(
             v._cpp_object, quadrature_degree, integration_entities
         )
         if space == "DG" and degree == 1:
-            assert np.allclose(0.0, coeffs)
+            np.testing.assert_allclose(0.0, coeffs)
         else:
             expr = Expression(grad(v), quadrature_points, comm=mesh.comm)
             expr_vals = expr.eval(mesh, cells)
-            assert np.allclose(coeffs, expr_vals)
+            np.testing.assert_allclose(coeffs, expr_vals)
 
 
 @pytest.mark.parametrize("quadrature_degree", range(1, 6))
@@ -135,7 +135,7 @@ def test_pack_coeff_on_facet(quadrature_degree, space, degree):
 
     for i, entity in enumerate(integration_entities):
         local_index = entity[1]
-        assert np.allclose(
+        np.testing.assert_allclose(
             coeffs[i], expr_vals[i, cstride * local_index : cstride * (local_index + 1)]
         )
     if space not in ["N1curl", "RTCE"]:
@@ -143,14 +143,14 @@ def test_pack_coeff_on_facet(quadrature_degree, space, degree):
             v._cpp_object, quadrature_degree, integration_entities
         )
         if space == "DG" and degree == 1:
-            assert np.allclose(0.0, coeffs)
+            np.testing.assert_allclose(0.0, coeffs)
         else:
             gdim = mesh.geometry.dim
             expr = Expression(grad(v), q_points, comm=mesh.comm)
             expr_vals = expr.eval(mesh, integration_entities[:, 0])
             for i, entity in enumerate(integration_entities):
                 local_index = entity[1]
-                assert np.allclose(
+                np.testing.assert_allclose(
                     coeffs[i],
                     expr_vals[i, gdim * cstride * local_index : gdim * cstride * (local_index + 1)],
                 )
@@ -193,7 +193,7 @@ def test_sub_coeff(quadrature_degree, degree):
         expr = Expression(vi, quadrature_points)
         expr_vals = expr.eval(mesh, cells)
 
-        assert np.allclose(coeffs, expr_vals)
+        np.testing.assert_allclose(coeffs, expr_vals)
 
 
 @pytest.mark.parametrize("quadrature_degree", range(1, 5))
@@ -233,4 +233,4 @@ def test_sub_coeff_grad(quadrature_degree, degree):
         expr = Expression(grad(vi), quadrature_points)
         expr_vals = expr.eval(mesh, cells)
 
-        assert np.allclose(coeffs, expr_vals)
+        np.testing.assert_allclose(coeffs, expr_vals)

--- a/python/tests/test_coeffs.py
+++ b/python/tests/test_coeffs.py
@@ -70,7 +70,7 @@ def test_pack_coeff_at_quadrature(ct, quadrature_degree, space, degree):
     # Use Expression to verify packing
     expr = Expression(v, quadrature_points)
     expr_vals = expr.eval(mesh, cells)
-    eps = 1e4*np.finfo(default_real_type).eps
+    eps = 1e4 * np.finfo(default_real_type).eps
     np.testing.assert_allclose(coeffs, expr_vals, atol=eps)
     if space not in ["N1curl", "RTCE"]:
         coeffs = dolfinx_contact.cpp.pack_gradient_quadrature(
@@ -133,12 +133,12 @@ def test_pack_coeff_on_facet(quadrature_degree, space, degree):
     q_points = q_rule.points()
     expr = Expression(v, q_points)
     expr_vals = expr.eval(mesh, integration_entities[:, 0])
-    eps = 1000*np.finfo(default_real_type).eps
+    eps = 1000 * np.finfo(default_real_type).eps
     for i, entity in enumerate(integration_entities):
         local_index = entity[1]
         np.testing.assert_allclose(
-            coeffs[i], expr_vals[i, cstride * local_index : cstride * (local_index + 1)]
-        ,atol=eps)
+            coeffs[i], expr_vals[i, cstride * local_index : cstride * (local_index + 1)], atol=eps
+        )
     if space not in ["N1curl", "RTCE"]:
         coeffs = dolfinx_contact.cpp.pack_gradient_quadrature(
             v._cpp_object, quadrature_degree, integration_entities
@@ -154,7 +154,7 @@ def test_pack_coeff_on_facet(quadrature_degree, space, degree):
                 np.testing.assert_allclose(
                     coeffs[i],
                     expr_vals[i, gdim * cstride * local_index : gdim * cstride * (local_index + 1)],
-                    atol=eps
+                    atol=eps,
                 )
 
 
@@ -184,7 +184,7 @@ def test_sub_coeff(quadrature_degree, degree):
     quadrature_points, wts = basix.make_quadrature(
         basix.CellType.tetrahedron, quadrature_degree, basix.QuadratureType.default
     )
-    eps = 1e4*np.finfo(default_real_type).eps
+    eps = 1e4 * np.finfo(default_real_type).eps
     num_sub_spaces = V.num_sub_spaces
     for i in range(num_sub_spaces):
         vi = v.sub(i)
@@ -225,7 +225,7 @@ def test_sub_coeff_grad(quadrature_degree, degree):
     quadrature_points, wts = basix.make_quadrature(
         basix.CellType.tetrahedron, quadrature_degree, basix.QuadratureType.default
     )
-    eps = 5e4*np.finfo(default_real_type).eps
+    eps = 5e4 * np.finfo(default_real_type).eps
     num_sub_spaces = V.num_sub_spaces
     for i in range(num_sub_spaces):
         vi = v.sub(i)

--- a/python/tests/test_contact_kernels.py
+++ b/python/tests/test_contact_kernels.py
@@ -179,7 +179,8 @@ def test_vector_surface_kernel(dim, kernel_type, P, Q):
     contact.assemble_vector(b2, 0, kernel, coeffs, consts, V._cpp_object)
     assemble_vector(b2, L_custom)
     b2.assemble()
-    np.testing.assert_allclose(b.array, b2.array)
+    eps = 5e1 * np.finfo(mesh.geometry.x.dtype).eps
+    np.testing.assert_allclose(b.array, b2.array, atol=eps)
 
 
 @pytest.mark.parametrize("kernel_type", [kt.Jac])

--- a/python/tests/test_contact_kernels.py
+++ b/python/tests/test_contact_kernels.py
@@ -179,7 +179,7 @@ def test_vector_surface_kernel(dim, kernel_type, P, Q):
     contact.assemble_vector(b2, 0, kernel, coeffs, consts, V._cpp_object)
     assemble_vector(b2, L_custom)
     b2.assemble()
-    assert np.allclose(b.array, b2.array)
+    np.testing.assert_allclose(b.array, b2.array)
 
 
 @pytest.mark.parametrize("kernel_type", [kt.Jac])

--- a/python/tests/test_copy_to_submesh.py
+++ b/python/tests/test_copy_to_submesh.py
@@ -134,4 +134,4 @@ def test_copy_to_submesh(tmp_path, order, res, simplex, dim):
     contact.copy_to_submesh(u._cpp_object, u_sub._cpp_object)
     u_exact = Function(V_sub)
     u_exact.interpolate(_test_fun)
-    assert np.allclose(u_sub.x.array[:], u_exact.x.array[:])
+    np.testing.assert_allclose(u_sub.x.array[:], u_exact.x.array[:])

--- a/python/tests/test_copy_to_submesh.py
+++ b/python/tests/test_copy_to_submesh.py
@@ -134,4 +134,5 @@ def test_copy_to_submesh(tmp_path, order, res, simplex, dim):
     contact.copy_to_submesh(u._cpp_object, u_sub._cpp_object)
     u_exact = Function(V_sub)
     u_exact.interpolate(_test_fun)
-    np.testing.assert_allclose(u_sub.x.array[:], u_exact.x.array[:])
+    eps = np.finfo(mesh.geometry.x.dtype).eps
+    np.testing.assert_allclose(u_sub.x.array[:], u_exact.x.array[:], atol=eps)

--- a/python/tests/test_dolfinx_custom.py
+++ b/python/tests/test_dolfinx_custom.py
@@ -78,7 +78,7 @@ def test_contact_kernel(tmp_path, theta, gamma, dim, gap):
         if i > 0:
             # Refine mesh
             mesh.topology.create_entities(mesh.topology.dim - 2)
-            mesh = dolfinx.mesh.refine(mesh)
+            mesh, _, _ = refine(mesh)
 
         # Create meshtag for top and bottom markers
         tdim = mesh.topology.dim

--- a/python/tests/test_dolfinx_custom.py
+++ b/python/tests/test_dolfinx_custom.py
@@ -263,7 +263,7 @@ def test_contact_kernel(tmp_path, theta, gamma, dim, gap):
         contact_assembler.assemble_matrix(B, 0, kernel, coeffs, consts, V._cpp_object)
         dolfinx.fem.petsc.assemble_matrix(B, a_custom)
         B.assemble()
-        assert np.allclose(b.array, b2.array)
+        np.testing.assert_allclose(b.array, b2.array)
         # Compare matrices, first norm, then entries
         assert np.isclose(A.norm(), B.norm())
         compare_matrices(A, B, atol=1e-7)

--- a/python/tests/test_dolfinx_custom.py
+++ b/python/tests/test_dolfinx_custom.py
@@ -78,7 +78,7 @@ def test_contact_kernel(tmp_path, theta, gamma, dim, gap):
         if i > 0:
             # Refine mesh
             mesh.topology.create_entities(mesh.topology.dim - 2)
-            mesh, _, _ = refine(mesh)
+            mesh, _, _ = dolfinx.mesh.refine(mesh)
 
         # Create meshtag for top and bottom markers
         tdim = mesh.topology.dim

--- a/python/tests/test_dolfinx_custom.py
+++ b/python/tests/test_dolfinx_custom.py
@@ -263,7 +263,8 @@ def test_contact_kernel(tmp_path, theta, gamma, dim, gap):
         contact_assembler.assemble_matrix(B, 0, kernel, coeffs, consts, V._cpp_object)
         dolfinx.fem.petsc.assemble_matrix(B, a_custom)
         B.assemble()
-        np.testing.assert_allclose(b.array, b2.array)
+        eps = 2e5 * np.finfo(mesh.geometry.x.dtype).eps
+        np.testing.assert_allclose(b.array, b2.array, atol=eps)
         # Compare matrices, first norm, then entries
         assert np.isclose(A.norm(), B.norm())
         compare_matrices(A, B, atol=1e-7)

--- a/python/tests/test_pack_u.py
+++ b/python/tests/test_pack_u.py
@@ -84,4 +84,4 @@ def test_pack_u():
 
         for j in range(len(s0)):
             f_exact = f(new_points[j].T).T.reshape(-1)
-            assert np.allclose(f_exact, u_opposite[j])
+            np.testing.assert_allclose(f_exact, u_opposite[j])

--- a/python/tests/test_packing_contact.py
+++ b/python/tests/test_packing_contact.py
@@ -127,6 +127,7 @@ def compare_test_fn(fn_space, test_fn, grad_test_fn, q_indices, link, x_ref, cel
 
     num_q_points = x_ref.shape[0]
     cell_arr = np.array(cell, dtype=np.int32)
+    eps = 2e2 * np.finfo(x_ref.dtype).eps
     for i, dof in enumerate(dofs):
         for k in range(bs):
             # Create fem function that is identical with desired test function
@@ -134,11 +135,11 @@ def compare_test_fn(fn_space, test_fn, grad_test_fn, q_indices, link, x_ref, cel
             v.x.array[:] = 0
             v.x.array[dof * bs + k] = 1
 
-            # Create expression vor evaluating test function and evaluate
+            # Create expression for evaluating test function and evaluate
             expr = _fem.Expression(v, x_ref)
             expr_vals = expr.eval(mesh, cell_arr)
 
-            # Create expression vor evaluating derivative of test
+            # Create expression for evaluating derivative of test
             # function and evaluate
             if bs == 1:
                 expr2 = _fem.Expression(ufl.grad(v), x_ref)
@@ -148,7 +149,7 @@ def compare_test_fn(fn_space, test_fn, grad_test_fn, q_indices, link, x_ref, cel
             # compare values of test functions
             offset = link * num_q_points * len(dofs) * bs + i * num_q_points * bs
             np.testing.assert_allclose(
-                expr_vals[0][q_indices * bs + k], test_fn[offset + q_indices * bs + k]
+                expr_vals[0][q_indices * bs + k], test_fn[offset + q_indices * bs + k], atol=eps
             )
             # retrieve dv from expression values and packed test fn
             dv1 = np.zeros((len(q_indices), gdim))
@@ -157,7 +158,7 @@ def compare_test_fn(fn_space, test_fn, grad_test_fn, q_indices, link, x_ref, cel
             for m in range(gdim):
                 dv1[:, m] = expr_vals2[0][q_indices * gdim + m]
                 dv2[:, m] = grad_test_fn[offset + q_indices * gdim + m]
-            np.testing.assert_allclose(dv1, dv2)
+            np.testing.assert_allclose(dv1, dv2, atol=eps)
 
 
 def assert_zero_test_fn(fn_space, test_fn, grad_test_fn, num_q_points, zero_ind, link, cell):
@@ -195,7 +196,8 @@ def compare_u(fn_space, u, u_opposite, grad_u_opposite, q_indices, x_ref, cell):
         vals[i * bs : (i + 1) * bs] = u_opposite[q * bs : (q + 1) * bs]
 
     # compare expression and packed u
-    np.testing.assert_allclose(expr_vals, vals)
+    eps = np.finfo(mesh.geometry.x.dtype).eps
+    np.testing.assert_allclose(expr_vals.flatten(), vals, atol=eps)
     # cell_arr = np.array(cell, dtype=np.int32).reshape(-1)
     # loop over block
     for k in range(bs):
@@ -219,10 +221,10 @@ def compare_u(fn_space, u, u_opposite, grad_u_opposite, q_indices, x_ref, cell):
                 vals2[j] = grad_u_opposite[index]
 
         # compare gradient from expression and u_opposite
-        np.testing.assert_allclose(vals1, vals2)
+        np.testing.assert_allclose(vals1, vals2, atol=eps)
 
 
-@pytest.mark.parametrize("ct", ["quadrilateral", "triangle", "tetrahedron", "hexahedron"])
+@pytest.mark.parametrize("ct", ["quadrilateral", "tetrahedron", "hexahedron", "triangle"])
 @pytest.mark.parametrize("gap", [0.5, -0.5])
 @pytest.mark.parametrize("q_deg", [1, 2, 3])
 @pytest.mark.parametrize("delta", [0.0, -0.5])

--- a/python/tests/test_packing_contact.py
+++ b/python/tests/test_packing_contact.py
@@ -147,7 +147,7 @@ def compare_test_fn(fn_space, test_fn, grad_test_fn, q_indices, link, x_ref, cel
             expr_vals2 = expr2.eval(mesh, cell)
             # compare values of test functions
             offset = link * num_q_points * len(dofs) * bs + i * num_q_points * bs
-            assert np.allclose(
+            np.testing.assert_allclose(
                 expr_vals[0][q_indices * bs + k], test_fn[offset + q_indices * bs + k]
             )
             # retrieve dv from expression values and packed test fn
@@ -157,7 +157,7 @@ def compare_test_fn(fn_space, test_fn, grad_test_fn, q_indices, link, x_ref, cel
             for m in range(gdim):
                 dv1[:, m] = expr_vals2[0][q_indices * gdim + m]
                 dv2[:, m] = grad_test_fn[offset + q_indices * gdim + m]
-            assert np.allclose(dv1, dv2)
+            np.testing.assert_allclose(dv1, dv2)
 
 
 def assert_zero_test_fn(fn_space, test_fn, grad_test_fn, num_q_points, zero_ind, link, cell):
@@ -170,14 +170,14 @@ def assert_zero_test_fn(fn_space, test_fn, grad_test_fn, num_q_points, zero_ind,
         for k in range(bs):
             # ensure values are zero if q not connected to quadrature point
             offset = link * num_q_points * len(dofs) * bs + i * num_q_points * bs
-            assert np.allclose(0, test_fn[offset + zero_ind * bs + k])
+            np.testing.assert_allclose(0, test_fn[offset + zero_ind * bs + k])
             # retrieve dv from expression values and packed test fn
             if len(zero_ind) > 0:
                 dv2 = np.zeros((len(zero_ind), gdim))
                 offset = link * num_q_points * len(dofs) * gdim + i * gdim * num_q_points
                 for m in range(gdim):
                     dv2[:, m] = grad_test_fn[offset + zero_ind * gdim + m]
-                assert np.allclose(np.zeros((len(zero_ind), gdim)), dv2)
+                np.testing.assert_allclose(np.zeros((len(zero_ind), gdim)), dv2)
 
 
 def compare_u(fn_space, u, u_opposite, grad_u_opposite, q_indices, x_ref, cell):
@@ -195,7 +195,7 @@ def compare_u(fn_space, u, u_opposite, grad_u_opposite, q_indices, x_ref, cell):
         vals[i * bs : (i + 1) * bs] = u_opposite[q * bs : (q + 1) * bs]
 
     # compare expression and packed u
-    assert np.allclose(expr_vals, vals)
+    np.testing.assert_allclose(expr_vals, vals)
     # cell_arr = np.array(cell, dtype=np.int32).reshape(-1)
     # loop over block
     for k in range(bs):
@@ -219,7 +219,7 @@ def compare_u(fn_space, u, u_opposite, grad_u_opposite, q_indices, x_ref, cell):
                 vals2[j] = grad_u_opposite[index]
 
         # compare gradient from expression and u_opposite
-        assert np.allclose(vals1, vals2)
+        np.testing.assert_allclose(vals1, vals2)
 
 
 @pytest.mark.parametrize("ct", ["quadrilateral", "triangle", "tetrahedron", "hexahedron"])

--- a/python/tests/test_projection.py
+++ b/python/tests/test_projection.py
@@ -129,4 +129,4 @@ def test_projection(tmp_path, q_deg, surf, dim):
 
     # Test if angle between -normal and gap function is less than 6.5 degrees
     # Is better accuracy needed?
-    assert np.allclose(n_dot, np.ones(n_dot.shape))
+    np.testing.assert_allclose(n_dot, np.ones(n_dot.shape))

--- a/python/tests/test_raytracing.py
+++ b/python/tests/test_raytracing.py
@@ -57,7 +57,8 @@ def test_raytracing_3D(cell_type):
             cell_geometry[i, :] = mesh.geometry.x[dof, :]
 
         distance = dolfinx.geometry.compute_distance_gjk(cell_geometry, origin)
-        np.testing.assert_allclose(x, origin + distance)
+        tol = 5 * np.finfo(mesh.geometry.x.dtype).eps
+        np.testing.assert_allclose(x, origin + distance, atol=tol)
 
 
 @pytest.mark.parametrize(
@@ -138,7 +139,8 @@ def test_raytracing_2D(cell_type):
         for i, dof in enumerate(cell_dofs):
             cell_geometry[i, :] = mesh.geometry.x[dof, :]
         distance = dolfinx.geometry.compute_distance_gjk(cell_geometry, origin)
-        np.testing.assert_allclose(x, origin + distance[:2])
+        tol = 5 * np.finfo(mesh.geometry.x.dtype).eps
+        np.testing.assert_allclose(x, origin + distance[:2], atol=tol)
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_raytracing.py
+++ b/python/tests/test_raytracing.py
@@ -57,7 +57,7 @@ def test_raytracing_3D(cell_type):
             cell_geometry[i, :] = mesh.geometry.x[dof, :]
 
         distance = dolfinx.geometry.compute_distance_gjk(cell_geometry, origin)
-        assert np.allclose(x, origin + distance)
+        np.testing.assert_allclose(x, origin + distance)
 
 
 @pytest.mark.parametrize(
@@ -97,7 +97,7 @@ def test_raytracing_3D_corner(cell_type):
         for i, dof in enumerate(cell_dofs):
             cell_geometry[i, :] = mesh.geometry.x[dof, :]
         distance = dolfinx.geometry.compute_distance_gjk(cell_geometry, origin)
-        assert np.allclose(x, origin + distance)
+        np.testing.assert_allclose(x, origin + distance)
 
 
 @pytest.mark.parametrize(
@@ -138,7 +138,7 @@ def test_raytracing_2D(cell_type):
         for i, dof in enumerate(cell_dofs):
             cell_geometry[i, :] = mesh.geometry.x[dof, :]
         distance = dolfinx.geometry.compute_distance_gjk(cell_geometry, origin)
-        assert np.allclose(x, origin + distance[:2])
+        np.testing.assert_allclose(x, origin + distance[:2])
 
 
 @pytest.mark.parametrize(
@@ -178,7 +178,7 @@ def test_raytracing_2D_corner(cell_type):
         for i, dof in enumerate(cell_dofs):
             cell_geometry[i, :] = mesh.geometry.x[dof, :]
         distance = dolfinx.geometry.compute_distance_gjk(cell_geometry, origin)
-        assert np.allclose(x, origin + distance[:2])
+        np.testing.assert_allclose(x, origin + distance[:2])
 
 
 @pytest.mark.parametrize(
@@ -210,4 +210,4 @@ def test_raytracing_manifold(cell_type):
     status, cell_idx, x, X = dolfinx_contact.cpp.raytracing(
         mesh._cpp_object, origin, normal, integral_pairs, 10, 1e-6
     )
-    assert np.allclose(x, exact_point)
+    np.testing.assert_allclose(x, exact_point)

--- a/python/tests/test_unbiased.py
+++ b/python/tests/test_unbiased.py
@@ -898,7 +898,7 @@ class TestUnbiased:
         contact_problem.assemble_vector(b1.x.petsc_vec, V_custom)
         b1.x.scatter_reverse(la.InsertMode.add)
         b1.x.scatter_forward()
-        assert np.allclose(b0.x.array[ind_dg], b1.x.array)
+        np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array)
 
         # Assemble  jacobian
         A1.zeroEntries()
@@ -917,7 +917,7 @@ class TestUnbiased:
             bi, bj, bv = A1.getValuesCSR()
             B_sp = scipy.sparse.csr_matrix((bv, bj, bi), shape=A1.getSize()).todense()
 
-            assert np.allclose(A_sp[ind_dg, :][:, ind_dg], B_sp)
+            np.testing.assert_allclose(A_sp[ind_dg, :][:, ind_dg], B_sp)
 
         # Sanity check different formulations
         if frictionlaw == FrictionLaw.Frictionless:
@@ -930,7 +930,7 @@ class TestUnbiased:
             _fem.petsc.assemble_vector(b2.x.petsc_vec, F2)
             b2.x.scatter_reverse(la.InsertMode.add)
             b2.x.scatter_forward()
-            assert np.allclose(b1.x.array, b2.x.array[ind_dg])
+            np.testing.assert_allclose(b1.x.array, b2.x.array[ind_dg])
 
             # Contact terms formulated using ufl consistent with nitsche_ufl.py
             # FIXME: Add parallel matrix comparison
@@ -944,7 +944,7 @@ class TestUnbiased:
 
                 ci, cj, cv = A2.getValuesCSR()
                 C_sp = scipy.sparse.csr_matrix((cv, cj, ci), shape=A2.getSize()).todense()
-                assert np.allclose(C_sp[ind_dg, :][:, ind_dg], B_sp)
+                np.testing.assert_allclose(C_sp[ind_dg, :][:, ind_dg], B_sp)
 
     @pytest.mark.xdist_group(name="group1")
     @pytest.mark.skipif(
@@ -1158,7 +1158,7 @@ class TestUnbiased:
         ind_dg = compute_dof_permutations_all(V_ufl, V_custom, gap)
 
         # Compare rhs
-        assert np.allclose(b0.x.array[ind_dg], b1.x.array)
+        np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array)
 
         # create scipy matrix
         # FIXME: Add parallel matrix comparison
@@ -1167,4 +1167,4 @@ class TestUnbiased:
             A_sp = scipy.sparse.csr_matrix((av, aj, ai), shape=A0.getSize()).todense()
             bi, bj, bv = A1.getValuesCSR()
             B_sp = scipy.sparse.csr_matrix((bv, bj, bi), shape=A1.getSize()).todense()
-            assert np.allclose(A_sp[:, ind_dg][ind_dg, :], B_sp)
+            np.testing.assert_allclose(A_sp[:, ind_dg][ind_dg, :], B_sp)

--- a/python/tests/test_unbiased.py
+++ b/python/tests/test_unbiased.py
@@ -898,7 +898,7 @@ class TestUnbiased:
         contact_problem.assemble_vector(b1.x.petsc_vec, V_custom)
         b1.x.scatter_reverse(la.InsertMode.add)
         b1.x.scatter_forward()
-        tol = 2000*np.finfo(mesh_custom.geometry.x.dtype).eps
+        tol = 2000 * np.finfo(mesh_custom.geometry.x.dtype).eps
         np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array, atol=tol)
 
         # Assemble  jacobian

--- a/python/tests/test_unbiased.py
+++ b/python/tests/test_unbiased.py
@@ -898,7 +898,7 @@ class TestUnbiased:
         contact_problem.assemble_vector(b1.x.petsc_vec, V_custom)
         b1.x.scatter_reverse(la.InsertMode.add)
         b1.x.scatter_forward()
-        tol = 2000 * np.finfo(mesh_custom.geometry.x.dtype).eps
+        tol = 1e-11
         np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array, atol=tol)
 
         # Assemble  jacobian
@@ -908,7 +908,6 @@ class TestUnbiased:
 
         # Retrieve data necessary for comparison
         tdim = mesh_ufl.topology.dim
-
         # create scipy matrix
         # FIXME: Add parallel matrix comparison
         if MPI.COMM_WORLD.size < 2:
@@ -1158,7 +1157,7 @@ class TestUnbiased:
         tdim = mesh_ufl.topology.dim
         ind_dg = compute_dof_permutations_all(V_ufl, V_custom, gap)
 
-        tol = 2000 * np.finfo(mesh_custom.geometry.x.dtype).eps
+        tol = 1e-11
 
         # Compare rhs
         np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array, atol=tol)

--- a/python/tests/test_unbiased.py
+++ b/python/tests/test_unbiased.py
@@ -898,7 +898,7 @@ class TestUnbiased:
         contact_problem.assemble_vector(b1.x.petsc_vec, V_custom)
         b1.x.scatter_reverse(la.InsertMode.add)
         b1.x.scatter_forward()
-        tol = 1e-11
+        tol = 5e-9
         np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array, atol=tol)
 
         # Assemble  jacobian

--- a/python/tests/test_unbiased.py
+++ b/python/tests/test_unbiased.py
@@ -898,7 +898,8 @@ class TestUnbiased:
         contact_problem.assemble_vector(b1.x.petsc_vec, V_custom)
         b1.x.scatter_reverse(la.InsertMode.add)
         b1.x.scatter_forward()
-        np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array)
+        tol = 2000*np.finfo(mesh_custom.geometry.x.dtype).eps
+        np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array, atol=tol)
 
         # Assemble  jacobian
         A1.zeroEntries()
@@ -917,7 +918,7 @@ class TestUnbiased:
             bi, bj, bv = A1.getValuesCSR()
             B_sp = scipy.sparse.csr_matrix((bv, bj, bi), shape=A1.getSize()).todense()
 
-            np.testing.assert_allclose(A_sp[ind_dg, :][:, ind_dg], B_sp)
+            np.testing.assert_allclose(A_sp[ind_dg, :][:, ind_dg], B_sp, atol=tol)
 
         # Sanity check different formulations
         if frictionlaw == FrictionLaw.Frictionless:
@@ -930,7 +931,7 @@ class TestUnbiased:
             _fem.petsc.assemble_vector(b2.x.petsc_vec, F2)
             b2.x.scatter_reverse(la.InsertMode.add)
             b2.x.scatter_forward()
-            np.testing.assert_allclose(b1.x.array, b2.x.array[ind_dg])
+            np.testing.assert_allclose(b1.x.array, b2.x.array[ind_dg], atol=tol)
 
             # Contact terms formulated using ufl consistent with nitsche_ufl.py
             # FIXME: Add parallel matrix comparison
@@ -944,7 +945,7 @@ class TestUnbiased:
 
                 ci, cj, cv = A2.getValuesCSR()
                 C_sp = scipy.sparse.csr_matrix((cv, cj, ci), shape=A2.getSize()).todense()
-                np.testing.assert_allclose(C_sp[ind_dg, :][:, ind_dg], B_sp)
+                np.testing.assert_allclose(C_sp[ind_dg, :][:, ind_dg], B_sp, atol=tol)
 
     @pytest.mark.xdist_group(name="group1")
     @pytest.mark.skipif(
@@ -1157,8 +1158,10 @@ class TestUnbiased:
         tdim = mesh_ufl.topology.dim
         ind_dg = compute_dof_permutations_all(V_ufl, V_custom, gap)
 
+        tol = 2000 * np.finfo(mesh_custom.geometry.x.dtype).eps
+
         # Compare rhs
-        np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array)
+        np.testing.assert_allclose(b0.x.array[ind_dg], b1.x.array, atol=tol)
 
         # create scipy matrix
         # FIXME: Add parallel matrix comparison
@@ -1167,4 +1170,4 @@ class TestUnbiased:
             A_sp = scipy.sparse.csr_matrix((av, aj, ai), shape=A0.getSize()).todense()
             bi, bj, bv = A1.getValuesCSR()
             B_sp = scipy.sparse.csr_matrix((bv, bj, bi), shape=A1.getSize()).todense()
-            np.testing.assert_allclose(A_sp[:, ind_dg][ind_dg, :], B_sp)
+            np.testing.assert_allclose(A_sp[:, ind_dg][ind_dg, :], B_sp, atol=tol)


### PR DESCRIPTION
A few bugs have been found with this PR:
- Radix sort broken for negative indices (https://github.com/FEniCS/dolfinx/pull/3724)
- A bug in the packing of gradients of test-functions, which would break on manifolds.
- "pc_mg_levels" is not allowed as input when using GAMG (explicit error thrown in newer versions of PETSc).

Several API changes in DOLFINx:
- `create_form` takes in entity_maps (in all C++ examples it is an empty std::map).
- `dolfinx.mesh.refine` has new output (the cell and parent maps).
- `set_bc` has been refactored in DOLFINx, use the appropriate version in the relevant C++ demos
- Radix sort has been rewritten in DOLFINx (use new API, even with the issue mentioned above)
- "scale" in `apply_lifting` is now called `alpha`

Other improvements:
- Use `numpy.testing.assert_allclose` to get a better debug output in tests.
