### PR TITLE
API fixes pre 0.11 release

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - name: Install linting tools
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/fenics/dolfinx/dolfinx:stable
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build C++ docs
         run: |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ simulations. It builds on the
 dolfinx-contact is under heavy development and is highly experimental.
 
 ## Installation
-DOLFINx contact requires DOLFINx (v0.10.0) installed on your system.
+DOLFINx contact requires DOLFINx (v0.11.0) installed on your system.
 To build the library, you can call:
 ```bash
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 # Set project name and version number
-project(DOLFINX_CONTACT VERSION 0.10.0.0)
+project(DOLFINX_CONTACT VERSION 0.11.0.0)
 
 # -----------------------------------------------------------------------------
 # Set CMake options, see `cmake --help-policy CMP00xx`
@@ -60,8 +60,8 @@ add_feature_info(
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Find packages
-find_package(DOLFINX 0.9.0.0 REQUIRED)
-find_package(Basix 0.9.0.0 REQUIRED)
+find_package(DOLFINX 0.11.0.0 REQUIRED)
+find_package(Basix 0.11.0.0 REQUIRED)
 
 feature_summary(WHAT ALL)
 

--- a/cpp/Contact.cpp
+++ b/cpp/Contact.cpp
@@ -324,7 +324,13 @@ void Contact::create_distance_map(int pair)
 
   // NOTE: More data that should be updated inside this code
   const dolfinx::fem::CoordinateElement<double>& cmap
-      = candidate_mesh->geometry().cmap();
+      = candidate_mesh->geometry().cmaps().front();
+  if (candidate_mesh->geometry().cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of contact points at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::tie(_reference_basis, _reference_shape)
       = tabulate(cmap, _quadrature_rule);
 
@@ -355,8 +361,14 @@ std::pair<std::vector<PetscScalar>, int> Contact::pack_nx(int pair) const
   const dolfinx::mesh::Geometry<double>& geometry = quadrature_mesh->geometry();
   int gdim = geometry.dim();
   std::span<const double> x_g = geometry.x();
-  auto x_dofmap = geometry.dofmap();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+  auto x_dofmap = geometry.dofmaps().front();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of normals at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::size_t num_dofs_g = cmap.dim();
   auto topology = quadrature_mesh->topology();
   int tdim = topology->dim();
@@ -557,8 +569,14 @@ std::pair<std::vector<PetscScalar>, int> Contact::pack_gap(int pair) const
 
   // Get information about submesh geometry and topology
   std::span<const double> x_g = geometry.x();
-  auto x_dofmap = geometry.dofmap();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+  auto x_dofmap = geometry.dofmaps().front();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::size_t num_dofs_g = cmap.dim();
   auto topology = candidate_mesh->topology();
   int tdim = topology->dim();
@@ -958,7 +976,13 @@ std::pair<std::vector<PetscScalar>, int> Contact::pack_gap_plane(int pair,
 
   // Tabulate basis function on reference cell (_phi_ref_facets)
   const dolfinx::fem::CoordinateElement<double>& cmap
-      = _mesh->geometry().cmap();
+      = _mesh->geometry().cmaps().front();
+  if (_mesh->geometry().cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::tie(_reference_basis, _reference_shape)
       = tabulate(cmap, _quadrature_rule);
 
@@ -1028,8 +1052,14 @@ dolfinx_contact::Contact::pack_ny(int pair) const
 
   // Get information about submesh geometry and topology
   std::span<const double> x_g = geometry.x();
-  auto x_dofmap = geometry.dofmap();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+  auto x_dofmap = geometry.dofmaps().front();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::size_t num_dofs_g = cmap.dim();
   auto topology = candidate_mesh->topology();
   int tdim = topology->dim();
@@ -1144,9 +1174,15 @@ void Contact::assemble_matrix(mat_set_fn& mat_set, int pair,
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      x_dofmap = geometry.dofmap();
+      x_dofmap = geometry.dofmaps().front();
   std::span<const double> x_g = geometry.x();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::size_t num_dofs_g = cmap.dim();
   if (V.element()->needs_dof_transformations())
   {
@@ -1270,10 +1306,16 @@ void Contact::assemble_vector(std::span<PetscScalar> b, int pair,
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      x_dofmap = geometry.dofmap();
+      x_dofmap = geometry.dofmaps().front();
   std::span<const double> x_g = geometry.x();
 
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::size_t num_dofs_g = cmap.dim();
 
   // Extract function space data (assuming same test and trial space)
@@ -1463,7 +1505,7 @@ std::pair<std::vector<PetscScalar>, int> Contact::pack_grad_test_functions(
           = std::span(perm.data() + offsets[j], offsets[j + 1] - offsets[j]);
 
       // Extract local dofs
-      assert(std::size_t(linked_cell) < mesh->geometry().dofmap().extent(0));
+      assert(std::size_t(linked_cell) < mesh->geometry().dofmaps().front().extent(0));
       std::vector<double> x_c(indices.size() * tdim);
       for (std::size_t l = 0; l < indices.size(); l++)
       {

--- a/cpp/KernelData.cpp
+++ b/cpp/KernelData.cpp
@@ -17,7 +17,13 @@ dolfinx_contact::KernelData::KernelData(
   assert(mesh);
   // Get mesh info
   const dolfinx::mesh::Geometry<double>& geometry = mesh->geometry();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
 
   _affine = cmap.is_affine();
   _num_coordinate_dofs = cmap.dim();

--- a/cpp/RayTracing.h
+++ b/cpp/RayTracing.h
@@ -437,14 +437,18 @@ compute_ray(const dolfinx::mesh::Mesh<double>& mesh,
   if (mesh.topology()->dim() != tdim or mesh.geometry().dim() != gdim)
     throw std::invalid_argument("Invalid topological or geometrical dimension");
 
-  const dolfinx::fem::CoordinateElement<double>& cmap = mesh.geometry().cmap();
-
+  const dolfinx::fem::CoordinateElement<double>& cmap = mesh.geometry().cmaps().front();
+  if (mesh.geometry().cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Ray tracing not implemented for meshes with multiple coordinate maps.");
+  }
   // Get cell coordinates/geometry
   const dolfinx::mesh::Geometry<double>& geometry = mesh.geometry();
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      x_dofmap = geometry.dofmap();
+      x_dofmap = geometry.dofmaps().front();
   std::span<const double> x_g = geometry.x();
   const std::size_t num_dofs_g = cmap.dim();
   std::vector<double> coordinate_dofs(num_dofs_g * gdim);

--- a/cpp/coefficients.cpp
+++ b/cpp/coefficients.cpp
@@ -153,8 +153,14 @@ dolfinx_contact::pack_coefficient_quadrature(
     MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
         const std::int32_t,
         MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        x_dofmap = mesh->geometry().dofmap();
-    const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+        x_dofmap = mesh->geometry().dofmaps().front();
+    const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+    if (geometry.cmaps().size() > 1)
+    {
+      throw std::invalid_argument(
+          "Packing of coefficients at quadrature points not implemented for "
+          "meshes with multiple coordinate maps.");
+    }
     const std::size_t num_dofs_g = cmap.dim();
     std::span<const double> x_g = geometry.x();
 
@@ -385,9 +391,14 @@ dolfinx_contact::pack_gradient_quadrature(
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      x_dofmap = geometry.dofmap();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
-
+      x_dofmap = geometry.dofmaps().front();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gradients at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const double> x_g = geometry.x();
 
@@ -560,9 +571,12 @@ dolfinx_contact::pack_circumradius(const dolfinx::mesh::Mesh<double>& mesh,
   const dolfinx::mesh::Geometry<double>& geometry = mesh.geometry();
 
   auto topology = mesh.topology();
-  if (!geometry.cmap().is_affine())
+  if (!geometry.cmaps().front().is_affine())
     throw std::invalid_argument("Non-affine circumradius is not implemented");
-
+  if (geometry.cmaps().size() > 1)
+    throw std::invalid_argument(
+        "Packing of circumradius at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
   // Tabulate element at quadrature points
   const dolfinx::mesh::CellType cell_type = topology->cell_type();
   error::check_cell_type(cell_type);
@@ -579,7 +593,7 @@ dolfinx_contact::pack_circumradius(const dolfinx::mesh::Mesh<double>& mesh,
   assert(q_rule.tdim() == (std::size_t)tdim);
 
   // Tabulate coordinate basis for Jacobian computation
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
   const std::array<std::size_t, 4> tab_shape
       = cmap.tabulate_shape(1, sum_q_points);
   std::vector<double> coordinate_basisb(
@@ -597,7 +611,13 @@ dolfinx_contact::pack_circumradius(const dolfinx::mesh::Mesh<double>& mesh,
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      x_dofmap = geometry.dofmap();
+      x_dofmap = geometry.dofmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of circumradius at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::span<const double> x_g = geometry.x();
 
   // Prepare temporary data structures data structures

--- a/cpp/demos/meshtie/CMakeLists.txt
+++ b/cpp/demos/meshtie/CMakeLists.txt
@@ -30,16 +30,19 @@ else()
     message(STATUS "** This demo does not support single precision")
   endif()
 endif()
-# Create compilation command
+# Create compilation command (added the .h file to OUTPUT)
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.h
   COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py
-  COMMENT "Compiling ${ufl_file}.py with ${SCALAR_TYPE}"
+  COMMENT "Compiling ${ufl_file}.py"
 )
 
+# Reference the generated .c file using its absolute path in the binary directory
+add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c)
 
-add_executable(${PROJECT_NAME} main.cpp ${ufl_file}.c)
+# Explicitly tell the target where to find the generated heat_equation.h
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # Copy mesh files into binary directory
 function(copy_meshes_to_target_dir target)

--- a/cpp/demos/meshtie/CMakeLists.txt
+++ b/cpp/demos/meshtie/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 # Create compilation command (added the .h file to OUTPUT)
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.h
-  COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py
   COMMENT "Compiling ${ufl_file}.py"
 )

--- a/cpp/demos/meshtie/linear_elasticity.py
+++ b/cpp/demos/meshtie/linear_elasticity.py
@@ -9,19 +9,18 @@
 from basix.ufl import element
 from ufl import (
     Coefficient,
+    FunctionSpace,
+    Identity,
+    Mesh,
+    TestFunction,
+    TrialFunction,
     ds,
     dx,
-    FunctionSpace,
     grad,
-    Identity,
     inner,
-    Mesh,
     sym,
-    TestFunction,
     tr,
-    TrialFunction,
 )
-
 
 # tags for boundaries (see mesh file)
 neumann_bdy = 7

--- a/cpp/demos/meshtie/main.cpp
+++ b/cpp/demos/meshtie/main.cpp
@@ -87,9 +87,8 @@ int main(int argc, char* argv[])
         [lmbda_val](
             auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
         {
-          std::vector<T> _f;
-          for (std::size_t p = 0; p < x.extent(1); ++p)
-            _f.push_back(lmbda_val);
+          std::vector<T> _f(x.extent(1));
+          std::fill(_f.begin(), _f.end(), lmbda_val);
           return {_f, {_f.size()}};
         });
 
@@ -98,11 +97,11 @@ int main(int argc, char* argv[])
     mu->interpolate(
         [mu_val](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
         {
-          std::vector<T> _f;
-          for (std::size_t p = 0; p < x.extent(1); ++p)
-            _f.push_back(mu_val);
+          std::vector<T> _f(x.extent(1));
+          std::fill(_f.begin(), _f.end(), mu_val);
           return {_f, {_f.size()}};
         });
+  spdlog::warn("f interpolate");
 
     // Function for body force
     auto f = std::make_shared<dolfinx::fem::Function<T>>(V);
@@ -119,6 +118,7 @@ int main(int argc, char* argv[])
             _f(1, p) = 0.5;
           return {std::move(fdata), {bs, x.extent(1)}};
         });
+  spdlog::warn("f interpolate end");
 
     // Function for surface traction
     auto t = std::make_shared<dolfinx::fem::Function<T>>(V);
@@ -135,6 +135,9 @@ int main(int argc, char* argv[])
             _f(1, p) = 0.5;
           return {std::move(fdata), {bs, x.extent(1)}};
         });
+
+  spdlog::warn("Interpolated functions");
+
 
     // Create integration domains for integrating over specific surfaces
     std::vector<std::pair<std::int32_t, std::span<const std::int32_t>>>

--- a/cpp/demos/meshtieHeatEquation/CMakeLists.txt
+++ b/cpp/demos/meshtieHeatEquation/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # Create compilation command
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c
-  COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py
   COMMENT "Compiling ${ufl_file}.py"
 )

--- a/cpp/demos/meshtieHeatEquation/heat_equation.py
+++ b/cpp/demos/meshtieHeatEquation/heat_equation.py
@@ -9,15 +9,15 @@
 from basix.ufl import element
 from ufl import (
     Coefficient,
-    dx,
     FunctionSpace,
-    grad,
-    lhs,
-    rhs,
-    inner,
     Mesh,
     TestFunction,
     TrialFunction,
+    dx,
+    grad,
+    inner,
+    lhs,
+    rhs,
 )
 
 # Mesh and elements

--- a/cpp/demos/meshtieHeatTransfer/CMakeLists.txt
+++ b/cpp/demos/meshtieHeatTransfer/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # Create compilation command (added the .h file to OUTPUT)
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.h
-  COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py
   COMMENT "Compiling ${ufl_file}.py"
 )

--- a/cpp/demos/meshtieHeatTransfer/CMakeLists.txt
+++ b/cpp/demos/meshtieHeatTransfer/CMakeLists.txt
@@ -17,15 +17,19 @@ set(ufl_file thermo_elasticity)
 if (PETSC_SCALAR_COMPLEX EQUAL 1)
   set(SCALAR_TYPE "--scalar_type=double _Complex")
 endif()
-# Create compilation command
+# Create compilation command (added the .h file to OUTPUT)
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.h
   COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py
   COMMENT "Compiling ${ufl_file}.py"
 )
 
-add_executable(${PROJECT_NAME} main.cpp ${ufl_file}.c)
+# Reference the generated .c file using its absolute path in the binary directory
+add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c)
+
+# Explicitly tell the target where to find the generated heat_equation.h
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # Copy mesh files into binary directory
 function(copy_meshes_to_target_dir target)

--- a/cpp/demos/meshtieHeatTransfer/thermo_elasticity.py
+++ b/cpp/demos/meshtieHeatTransfer/thermo_elasticity.py
@@ -9,19 +9,19 @@
 from basix.ufl import element
 from ufl import (
     Coefficient,
+    FunctionSpace,
+    Identity,
+    Mesh,
+    TestFunction,
+    TrialFunction,
     derivative,
     dx,
-    FunctionSpace,
     grad,
-    Identity,
     inner,
-    rhs,
     lhs,
-    Mesh,
+    rhs,
     sym,
-    TestFunction,
     tr,
-    TrialFunction,
 )
 
 # Mesh

--- a/cpp/demos/meshtieNewton/CMakeLists.txt
+++ b/cpp/demos/meshtieNewton/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # Create compilation command (added the .h file to OUTPUT)
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.h
-  COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py
   COMMENT "Compiling ${ufl_file}.py"
 )

--- a/cpp/demos/meshtieNewton/CMakeLists.txt
+++ b/cpp/demos/meshtieNewton/CMakeLists.txt
@@ -17,15 +17,19 @@ set(ufl_file linear_elasticity)
 if (PETSC_SCALAR_COMPLEX EQUAL 1)
   set(SCALAR_TYPE "--scalar_type=double _Complex")
 endif()
-# Create compilation command
+# Create compilation command (added the .h file to OUTPUT)
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.h
   COMMAND ffcx ${SCALAR_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py -o ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${ufl_file}.py
   COMMENT "Compiling ${ufl_file}.py"
 )
 
-add_executable(${PROJECT_NAME} main.cpp ${ufl_file}.c)
+# Reference the generated .c file using its absolute path in the binary directory
+add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/${ufl_file}.c)
+
+# Explicitly tell the target where to find the generated heat_equation.h
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # Copy mesh files into binary directory
 function(copy_meshes_to_target_dir target)

--- a/cpp/demos/meshtieNewton/linear_elasticity.py
+++ b/cpp/demos/meshtieNewton/linear_elasticity.py
@@ -9,19 +9,18 @@
 from basix.ufl import element
 from ufl import (
     Coefficient,
+    FunctionSpace,
+    Identity,
+    Mesh,
+    TestFunction,
+    TrialFunction,
     derivative,
     dx,
-    FunctionSpace,
     grad,
-    Identity,
     inner,
-    Mesh,
     sym,
-    TestFunction,
     tr,
-    TrialFunction,
 )
-
 
 e = element("Lagrange", "tetrahedron", 1, shape=(3,))
 e0 = element("DG", "tetrahedron", 0)

--- a/cpp/parallel_mesh_ghosting.cpp
+++ b/cpp/parallel_mesh_ghosting.cpp
@@ -196,7 +196,7 @@ dolfinx_contact::create_contact_mesh(
   dolfinx::common::Timer trepart("~Contact: Add ghosts: Repartition");
   auto new_mesh = dolfinx::mesh::create_mesh(
       mesh.comm(), mesh.comm(), topo_global, mesh.geometry().cmaps().front(),
-      mesh.comm(), x, xshape, partitioner, 1);
+      mesh.comm(), x, xshape, partitioner, 2);
   trepart.stop();
   if (mesh.geometry().cmaps().size() > 1)
   {

--- a/cpp/parallel_mesh_ghosting.cpp
+++ b/cpp/parallel_mesh_ghosting.cpp
@@ -195,9 +195,15 @@ dolfinx_contact::create_contact_mesh(
   spdlog::warn("Repartition");
   dolfinx::common::Timer trepart("~Contact: Add ghosts: Repartition");
   auto new_mesh = dolfinx::mesh::create_mesh(
-      mesh.comm(), mesh.comm(), topo_global, mesh.geometry().cmap(),
-      mesh.comm(), x, xshape, partitioner);
+      mesh.comm(), mesh.comm(), topo_global, mesh.geometry().cmaps().front(),
+      mesh.comm(), x, xshape, partitioner, 1);
   trepart.stop();
+  if (mesh.geometry().cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
 
   // Recreate facets
   new_mesh.topology()->create_entities(tdim - 1);

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -68,7 +68,8 @@ void dolfinx_contact::pull_back(
     mdspan_t<double, 3> J, mdspan_t<double, 3> K, std::span<double> detJ,
     std::span<double> X, mdspan_t<const double, 2> x,
     mdspan_t<const double, 2> coordinate_dofs,
-    const dolfinx::fem::CoordinateElement<double>& cmap)
+    const dolfinx::fem::CoordinateElement<double>& cmap,
+    std::size_t max_iter, double tol)
 {
   const std::size_t num_points = x.extent(0);
   assert(J.extent(0) >= num_points);
@@ -149,7 +150,7 @@ void dolfinx_contact::pull_back(
           J(i, j, k) = 0;
 
     mdspan_t<double, 2> Xs(X.data(), num_points, tdim);
-    cmap.pull_back_nonaffine(Xs, x, coordinate_dofs);
+    cmap.pull_back_nonaffine(Xs, x, coordinate_dofs, max_iter, tol);
 
     /// Tabulate coordinate basis at pull back points to compute the Jacobian,
     /// inverse and determinant
@@ -254,8 +255,13 @@ void dolfinx_contact::update_geometry(
   // The Function and the mesh must have identical element_dof_layouts
   // (up to the block size)
   assert(dofmap->element_dof_layout()
-         == mesh.geometry().cmap().create_dof_layout());
-
+         == mesh.geometry().cmaps().front().create_dof_layout());
+  if (mesh.geometry().cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   const int tdim = mesh.topology()->dim();
   std::shared_ptr<const dolfinx::common::IndexMap> cell_map
       = mesh.topology()->index_map(tdim);
@@ -267,7 +273,13 @@ void dolfinx_contact::update_geometry(
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      dofmap_x = mesh.geometry().dofmap();
+      dofmap_x = mesh.geometry().dofmaps().front();
+  if (mesh.geometry().dofmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   const int bs = dofmap->bs();
   const auto& u_data = u.x()->array();
   std::span<double> coords = mesh.geometry().x();
@@ -415,8 +427,14 @@ void dolfinx_contact::evaluate_basis_functions(
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      x_dofmap = geometry.dofmap();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+      x_dofmap = geometry.dofmaps().front();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   const std::size_t num_dofs_g = cmap.dim();
 
   // Get element
@@ -750,13 +768,19 @@ dolfinx_contact::entities_to_geometry_dofs(
   // Get mesh geometry and topology data
   const dolfinx::mesh::Geometry<double>& geometry = mesh.geometry();
   const dolfinx::fem::ElementDofLayout layout
-      = geometry.cmap().create_dof_layout();
-  // FIXME: What does this return for prisms?
-  const std::size_t num_entity_dofs = layout.num_entity_closure_dofs(dim);
+      = geometry.cmaps().front().create_dof_layout();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
+
+  const std::size_t num_entity_dofs = layout.entity_closure_dofs(dim, 0).size();
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      xdofs = geometry.dofmap();
+      xdofs = geometry.dofmaps().front();
 
   auto topology = mesh.topology();
   const int tdim = topology->dim();
@@ -940,12 +964,18 @@ void dolfinx_contact::compute_physical_points(
   // Geometrical info
   const dolfinx::mesh::Geometry<double>& geometry = mesh.geometry();
   std::span<const double> mesh_geometry = geometry.x();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   const std::size_t num_dofs_g = cmap.dim();
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      x_dofmap = geometry.dofmap();
+      x_dofmap = geometry.dofmaps().front();
   const int gdim = geometry.dim();
 
   // Create storage for output quadrature points
@@ -996,8 +1026,13 @@ dolfinx_contact::compute_distance_map(
 {
   dolfinx::common::Timer t("~Contact: compute distance map");
   const dolfinx::mesh::Geometry<double>& geometry = quadrature_mesh.geometry();
-  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmap();
-
+  const dolfinx::fem::CoordinateElement<double>& cmap = geometry.cmaps().front();
+  if (geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   std::size_t gdim = geometry.dim();
   auto topology = quadrature_mesh.topology();
   const dolfinx::mesh::CellType cell_type = topology->cell_type();

--- a/cpp/utils.cpp
+++ b/cpp/utils.cpp
@@ -150,7 +150,7 @@ void dolfinx_contact::pull_back(
           J(i, j, k) = 0;
 
     mdspan_t<double, 2> Xs(X.data(), num_points, tdim);
-    cmap.pull_back_nonaffine(Xs, x, coordinate_dofs, max_iter, tol);
+    cmap.pull_back_nonaffine(Xs, x, coordinate_dofs, tol, max_iter);
 
     /// Tabulate coordinate basis at pull back points to compute the Jacobian,
     /// inverse and determinant

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -97,11 +97,15 @@ using kernel_fn
 /// @param[in] x points on physical element
 /// @param[in] coordinate_dofs: geometry coordinates of cell
 /// @param[in] cmap: the coordinate element
+/// @param[in] max_iter: maximum number of iterations for Newton's method
+/// @param[in] tol: tolerance for convergence in Newton's method
 void pull_back(mdspan_t<double, 3> J, mdspan_t<double, 3> K,
                std::span<double> detJ, std::span<double> X,
                mdspan_t<const double, 2> x,
                mdspan_t<const double, 2> coordinate_dofs,
-               const dolfinx::fem::CoordinateElement<double>& cmap);
+               const dolfinx::fem::CoordinateElement<double>& cmap,
+               std::size_t max_iter = 100,
+               double tol = 1e-12);
 
 /// @param[in] cells: the cells to be sorted
 /// @param[in, out] perm the permutation for the sorted cells
@@ -393,6 +397,8 @@ facet_indices_from_pair(std::span<const std::int32_t> facet_pairs,
 /// local_facet_index) for the `quadrature_mesh`. Flattened row major.
 /// @param[in] points The points to compute the closest entity from.
 /// Shape (num_quadrature_points, 3). Flattened row-major
+/// @param[in] max_iter Maximum number of iterations for Newton's method
+/// @param[in] tol Tolerance for convergence in Newton's method
 /// @returns A tuple (closest_facets, reference_points), where
 /// `closest_entities[i]` is the closest entity in `facet_tuples` for
 /// the ith input point
@@ -401,7 +407,9 @@ std::tuple<std::vector<std::int32_t>, std::vector<double>,
            std::array<std::size_t, 2>>
 compute_projection_map(const dolfinx::mesh::Mesh<double>& mesh,
                        std::span<const std::int32_t> facet_tuples,
-                       std::span<const double> points)
+                       std::span<const double> points,
+                       std::size_t max_iter = 100,
+                       double tol = 1e-12)
 {
   assert(tdim == mesh.topology()->dim());
   assert(mesh.geometry().dim() == gdim);
@@ -439,7 +447,13 @@ compute_projection_map(const dolfinx::mesh::Mesh<double>& mesh,
                                                   points);
   std::vector<double> candidate_x(num_points * 3);
   std::span<const double> mesh_geometry = mesh.geometry().x();
-  const dolfinx::fem::CoordinateElement<double>& cmap = mesh.geometry().cmap();
+  const dolfinx::fem::CoordinateElement<double>& cmap = mesh.geometry().cmaps().front();
+  if (mesh.geometry().cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   {
     // Find displacement vector from each point to closest entity. As a
     // point on the surface might have penetrated the cell in question,
@@ -505,7 +519,13 @@ compute_projection_map(const dolfinx::mesh::Mesh<double>& mesh,
     MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
         const std::int32_t,
         MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        x_dofmap = mesh.geometry().dofmap();
+        x_dofmap = mesh.geometry().dofmaps().front();
+    if (mesh.geometry().dofmaps().size() > 1)
+    {
+      throw std::invalid_argument(
+          "Packing of gap function at quadrature points not implemented for "
+          "meshes with multiple coordinate maps.");
+    }
     std::vector<double> coordinate_dofsb(num_dofs_g * gdim);
     mdspan_t<const double, 2> coordinate_dofs(coordinate_dofsb.data(),
                                               num_dofs_g, gdim);
@@ -537,7 +557,7 @@ compute_projection_map(const dolfinx::mesh::Mesh<double>& mesh,
       // Pull back coordinates
       std::fill(Jb.begin(), Jb.end(), 0);
       pull_back(J, K, detJ, X, mdspan_t<const double, 2>(x.data(), 1, gdim),
-                coordinate_dofs, cmap);
+                coordinate_dofs, cmap, max_iter, tol);
       // Copy into output
       std::copy_n(X.begin(), tdim, std::next(candidate_X.begin(), i * tdim));
     }
@@ -614,13 +634,25 @@ compute_raytracing_map(const dolfinx::mesh::Mesh<double>& quadrature_mesh,
   // Get relevant information from quadrature mesh
   const dolfinx::mesh::Geometry<double>& geom_q = quadrature_mesh.geometry();
   const dolfinx::fem::CoordinateElement<double>& cmap_q
-      = quadrature_mesh.geometry().cmap();
+      = quadrature_mesh.geometry().cmaps().front();
+  if (quadrature_mesh.geometry().cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   auto top_q = quadrature_mesh.topology();
   std::span<const double> q_x = geom_q.x();
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      q_dofmap = geom_q.dofmap();
+      q_dofmap = geom_q.dofmaps().front();
+  if (geom_q.dofmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   const std::size_t num_nodes_q = cmap_q.dim();
   std::vector<double> coordinate_dofs_qb(num_nodes_q * gdim);
   mdspan_t<const double, 2> coordinate_dofs_q(coordinate_dofs_qb.data(),
@@ -646,11 +678,17 @@ compute_raytracing_map(const dolfinx::mesh::Mesh<double>& quadrature_mesh,
   // Structures used for raytracing
   dolfinx::mesh::CellType cell_type = candidate_mesh.topology()->cell_type();
   const dolfinx::mesh::Geometry<double>& c_geometry = candidate_mesh.geometry();
-  const dolfinx::fem::CoordinateElement<double>& cmap_c = c_geometry.cmap();
+  const dolfinx::fem::CoordinateElement<double>& cmap_c = c_geometry.cmaps().front();
+  if (c_geometry.cmaps().size() > 1)
+  {
+    throw std::invalid_argument(
+        "Packing of gap function at quadrature points not implemented for "
+        "meshes with multiple coordinate maps.");
+  }
   MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
       const std::int32_t,
       MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      c_dofmap = c_geometry.dofmap();
+      c_dofmap = c_geometry.dofmaps().front();
   std::span<const double> c_x = c_geometry.x();
 
   const std::array<std::size_t, 4> basis_shape_c = cmap_c.tabulate_shape(1, 1);

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -409,7 +409,7 @@ compute_projection_map(const dolfinx::mesh::Mesh<double>& mesh,
                        std::span<const std::int32_t> facet_tuples,
                        std::span<const double> points,
                        std::size_t max_iter = 100,
-                       double tol = 1e-6)
+                       double tol = 1.0e-6)
 {
   assert(tdim == mesh.topology()->dim());
   assert(mesh.geometry().dim() == gdim);

--- a/cpp/utils.h
+++ b/cpp/utils.h
@@ -105,7 +105,7 @@ void pull_back(mdspan_t<double, 3> J, mdspan_t<double, 3> K,
                mdspan_t<const double, 2> coordinate_dofs,
                const dolfinx::fem::CoordinateElement<double>& cmap,
                std::size_t max_iter = 100,
-               double tol = 1e-12);
+               double tol = 1e-6);
 
 /// @param[in] cells: the cells to be sorted
 /// @param[in, out] perm the permutation for the sorted cells
@@ -409,7 +409,7 @@ compute_projection_map(const dolfinx::mesh::Mesh<double>& mesh,
                        std::span<const std::int32_t> facet_tuples,
                        std::span<const double> points,
                        std::size_t max_iter = 100,
-                       double tol = 1e-12)
+                       double tol = 1e-6)
 {
   assert(tdim == mesh.topology()->dim());
   assert(mesh.geometry().dim() == gdim);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11>=2.6.4", "cmake>=3.16", "scikit-build>=0.12"]
+requires = ["setuptools>=42", "wheel", "scikit-build-core[pyproject]",
+      "nanobind>=1.8.0", "cmake>=3.16", "scikit-build>=0.12"]
 
 build-backend = "setuptools.build_meta"

--- a/python/dolfinx_contact/meshing/split_box.py
+++ b/python/dolfinx_contact/meshing/split_box.py
@@ -498,7 +498,7 @@ def create_hex_mesh(
     surface = gmsh.model.occ.addPlaneSurface([curve])
 
     num_layers = int(np.ceil(5 * z / res))
-    num_layers += 1 if num_layers % 2 == 1 else 0 
+    num_layers += 1 if num_layers % 2 == 1 else 0
 
     model.occ.extrude([(2, surface)], 0, 0, z, numElements=[num_layers], recombine=True)
     model.occ.synchronize()
@@ -533,6 +533,7 @@ def create_hex_mesh(
     model.mesh.generate(3)
     model.mesh.setOrder(order)
     gmsh.model.mesh.optimize("Netgen")
+
 
 def create_split_box_2D(
     filename: str,

--- a/python/dolfinx_contact/meshing/split_box.py
+++ b/python/dolfinx_contact/meshing/split_box.py
@@ -476,12 +476,38 @@ def create_hex_mesh(
     for point in pts:
         ps.append(gmsh.model.occ.addPoint(point[0], point[1], 0))
 
-    lines = [gmsh.model.occ.addLine(ps[i - 1], ps[i]) for i in range(len(ps))]
+    lines = []
+    line_elements = []
+    for i in range(len(ps)):
+        # Create the line
+        line_tag = gmsh.model.occ.addLine(ps[i - 1], ps[i])
+        lines.append(line_tag)
+
+        # Calculate the geometric length of the line
+        p1 = np.array(pts[i - 1][:2])
+        p2 = np.array(pts[i][:2])
+        length = np.linalg.norm(p2 - p1)
+
+        # Force an even number of elements based on 'res'
+        n_ele = max(2, int(np.ceil(length / res)))
+        if n_ele % 2 != 0:
+            n_ele += 1
+        line_elements.append(n_ele)
+
     curve = gmsh.model.occ.addCurveLoop(lines)
     surface = gmsh.model.occ.addPlaneSurface([curve])
 
-    model.occ.extrude([(2, surface)], 0, 0, z, numElements=[np.ceil(5 * z / res)], recombine=True)
+    num_layers = int(np.ceil(5 * z / res))
+    num_layers += 1 if num_layers % 2 == 1 else 0 
+
+    model.occ.extrude([(2, surface)], 0, 0, z, numElements=[num_layers], recombine=True)
     model.occ.synchronize()
+
+    # Explicitly apply the even element constraint to the base curves
+    for line_tag, n_ele in zip(lines, line_elements):
+        # Gmsh takes the number of NODES, which is elements + 1
+        gmsh.model.mesh.setTransfiniteCurve(line_tag, n_ele + 1)
+
     volumes = model.getEntities(3)
     surfaces = model.getEntities(2)
 
@@ -503,10 +529,10 @@ def create_hex_mesh(
     gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 2)
     gmsh.option.setNumber("Mesh.RecombineAll", 2)
     gmsh.option.setNumber("Mesh.SubdivisionAlgorithm", 1)
+
     model.mesh.generate(3)
     model.mesh.setOrder(order)
     gmsh.model.mesh.optimize("Netgen")
-
 
 def create_split_box_2D(
     filename: str,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,10 +12,10 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "dolfinx_contact"
-version = "0.10.0"
+version = "0.11.0"
 description = 'Contact custom assemblers using DOLFINx and Basix'
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.11.0"
 license = { file = "../LICENSE" }
 authors = [
       { email = "sr957@cam.ac.uk", name = "Sarah Roggendorf" },
@@ -26,7 +26,7 @@ dependencies = [
       "cffi",
       # "petsc4py",
       "mpi4py",
-      "fenics-dolfinx>=0.10.0",
+      "fenics-dolfinx>=0.11.0",
 ]
 
 [project.optional-dependencies]

--- a/python/tests/test_coeffs.py
+++ b/python/tests/test_coeffs.py
@@ -76,7 +76,7 @@ def test_pack_coeff_at_quadrature(ct, quadrature_degree, space, degree):
         coeffs = dolfinx_contact.cpp.pack_gradient_quadrature(
             v._cpp_object, quadrature_degree, integration_entities
         )
-        if space == "DG" and degree == 1:
+        if space in ("DG", "Discontinuous Lagrange") and degree == 1:
             np.testing.assert_allclose(0.0, coeffs, atol=eps)
         else:
             expr = Expression(grad(v), quadrature_points, comm=mesh.comm)
@@ -144,7 +144,7 @@ def test_pack_coeff_on_facet(quadrature_degree, space, degree):
         coeffs = dolfinx_contact.cpp.pack_gradient_quadrature(
             v._cpp_object, quadrature_degree, integration_entities
         )
-        if space == "DG" and degree == 1:
+        if space in ("DG", "Discontinuous Lagrange") and degree == 1:
             np.testing.assert_allclose(0.0, coeffs, atol=eps)
         else:
             gdim = mesh.geometry.dim

--- a/python/tests/test_pack_u.py
+++ b/python/tests/test_pack_u.py
@@ -26,7 +26,7 @@ def test_pack_u():
     cells = np.array([[0, 1, 2], [4, 5, 6], [1, 3, 2], [5, 6, 7]], dtype=np.int64)
 
     domain = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 1, shape=(points.shape[1],)))
-    part = msh.create_cell_partitioner(msh.GhostMode.none)
+    part = msh.create_cell_partitioner(msh.GhostMode.none, 2)
     mesh = msh.create_mesh(MPI.COMM_WORLD, cells=cells, x=points, e=domain, partitioner=part)
 
     def f(x):


### PR DESCRIPTION
- Fix deprecated num_entity_closure_dofs (undefined of prisms in old state)
- Various mixed-topology updates (DOLFINx side, not supported for contact yet).
- Update pullback (non-affine) to have max_iter and tolerances
- Fixes to stricter GMSH generation
- Update tests with new family name for elements.